### PR TITLE
Address real-world feedback

### DIFF
--- a/lib/graphiti/errors.rb
+++ b/lib/graphiti/errors.rb
@@ -16,19 +16,55 @@ The adapter #{@adapter.class} does not implement method '#{@method}', which was 
       end
     end
 
+    class InvalidFilterValue < Base
+      def initialize(resource, filter, value)
+        @resource = resource
+        @filter = filter
+        @value = value
+      end
+
+      def message
+        allow = @filter.values[0][:allow]
+        reject = @filter.values[0][:reject]
+        msg = <<-MSG
+#{@resource.class.name}: tried to filter on #{@filter.keys[0].inspect}, but passed invalid value #{@value.inspect}.
+        MSG
+        msg << "\nWhitelist: #{allow.inspect}" if allow
+        msg << "\nBlacklist: #{reject.inspect}" if reject
+        msg
+      end
+    end
+
     class InvalidLink < Base
-      def initialize(resource_class, sideload)
+      def initialize(resource_class, sideload, action)
         @resource_class = resource_class
         @sideload = sideload
+        @action = action
       end
 
       def message
         <<-MSG
 #{@resource_class.name}: Cannot link to sideload #{@sideload.name.inspect}!
 
-Make sure the endpoint "#{@sideload.resource.endpoint[:full_path]}" exists, or customize the endpoint for #{@sideload.resource.class.name}.
+Make sure the endpoint "#{@sideload.resource.endpoint[:full_path]}" exists with action #{@action.inspect}, or customize the endpoint for #{@sideload.resource.class.name}.
 
 If you do not wish to generate a link, pass link: false or set self.relationship_links_by_default = false.
+        MSG
+      end
+    end
+
+    class SingularFilter < Base
+      def initialize(resource, filter, value)
+        @resource = resource
+        @filter = filter
+        @value = value
+      end
+
+      def message
+        <<-MSG
+#{@resource.class.name}: passed multiple values to filter #{@filter.keys[0].inspect}, which was marked single: true.
+
+Value was: #{@value.inspect}
         MSG
       end
     end

--- a/lib/graphiti/resource.rb
+++ b/lib/graphiti/resource.rb
@@ -49,6 +49,7 @@ module Graphiti
     def typecast(name, value, flag)
       att = get_attr!(name, flag)
       type = Graphiti::Types[att[:type]]
+      return if value.nil? && type[:kind] != 'array'
       begin
         flag = :read if flag == :readable
         flag = :write if flag == :writable

--- a/lib/graphiti/resource/configuration.rb
+++ b/lib/graphiti/resource/configuration.rb
@@ -44,8 +44,8 @@ module Graphiti
           attr_writer :config
         end
 
-        class_attribute :adapter,
-          :model,
+        class_attribute :adapter, instance_reader: false
+        class_attribute :model,
           :type,
           :polymorphic,
           :polymorphic_child,
@@ -66,7 +66,7 @@ module Graphiti
         def self.inherited(klass)
           super
           klass.config = Util::Hash.deep_dup(config)
-          klass.adapter ||= Adapters::Abstract.new
+          klass.adapter ||= Adapters::Abstract
           klass.default_sort ||= []
           klass.default_page_size ||= 20
           # re-assigning causes a new Class.new
@@ -198,6 +198,10 @@ module Graphiti
 
       def get_attr(name, flag, request: false, raise_error: false)
         Util::AttributeCheck.run(self, name, flag, request, raise_error)
+      end
+
+      def adapter
+        @adapter ||= self.class.adapter.new(self)
       end
 
       def filters

--- a/lib/graphiti/resource/dsl.rb
+++ b/lib/graphiti/resource/dsl.rb
@@ -10,9 +10,17 @@ module Graphiti
           if att = get_attr(name, :filterable, raise_error: :only_unsupported)
             aliases = [name, opts[:aliases]].flatten.compact
             operators = FilterOperators.build(self, att[:type], opts, &blk)
+
+            if Graphiti::Types[att[:type]][:canonical_name] == :boolean
+              opts[:single] = true
+            end
+
             config[:filters][name.to_sym] = {
               aliases: aliases,
               type: att[:type],
+              allow: opts[:allow],
+              reject: opts[:reject],
+              single: !!opts[:single],
               operators: operators.to_hash
             }
           else
@@ -53,7 +61,7 @@ module Graphiti
         end
 
         def stat(symbol_or_hash, &blk)
-          dsl = Stats::DSL.new(adapter, symbol_or_hash)
+          dsl = Stats::DSL.new(new.adapter, symbol_or_hash)
           dsl.instance_eval(&blk) if blk
           config[:stats][dsl.name] = dsl
         end

--- a/lib/graphiti/resource/polymorphism.rb
+++ b/lib/graphiti/resource/polymorphism.rb
@@ -25,7 +25,7 @@ module Graphiti
       def associate(parent, child, association_name, type)
         child_resource = self.class.resource_for_model(parent)
         if child_resource.sideloads[association_name]
-          child_resource.adapter
+          child_resource.new.adapter
             .associate(parent, child, association_name, type)
         end
       end

--- a/lib/graphiti/resource/sideloading.rb
+++ b/lib/graphiti/resource/sideloading.rb
@@ -61,10 +61,10 @@ module Graphiti
           resource = resource ||= Util::Class.infer_resource_class(self, name)
           sideload = resource.sideload(as)
 
-          _adapter = adapter
+          _resource = resource
           filter sideload.true_foreign_key, resource.attributes[:id][:type] do
             eq do |scope, value|
-              _adapter.belongs_to_many_filter(sideload, scope, value)
+              _resource.new.adapter.belongs_to_many_filter(sideload, scope, value)
             end
           end
         end

--- a/lib/graphiti/schema.rb
+++ b/lib/graphiti/schema.rb
@@ -132,11 +132,15 @@ module Graphiti
 
     def filters(resource)
       {}.tap do |f|
-        resource.filters.each_pair do |name, config|
+        resource.filters.each_pair do |name, filter|
           config = {
-            type: config[:type].to_s,
-            operators: config[:operators].keys.map(&:to_s)
+            type: filter[:type].to_s,
+            operators: filter[:operators].keys.map(&:to_s)
           }
+          config[:single] = true if filter[:single]
+          config[:allow] = filter[:allow] if filter[:allow]
+          config[:reject] = filter[:reject] if filter[:reject]
+
           attr = resource.attributes[name]
           if attr[:filterable].is_a?(Symbol)
             if attr[:filterable] == :required

--- a/lib/graphiti/schema_diff.rb
+++ b/lib/graphiti/schema_diff.rb
@@ -94,6 +94,28 @@ module Graphiti
           next
         end
 
+        if new_filter[:single] && !old_filter[:single]
+          @errors << "#{old_resource[:name]}: filter #{name.inspect} became singular."
+        end
+
+        if new_filter[:allow] != old_filter[:allow]
+          new = new_filter[:allow] || []
+          old = old_filter[:allow] || []
+          diff = new - old
+          if diff.length > 0
+            @errors << "#{old_resource[:name]}: filter #{name.inspect} whitelist went from #{old.inspect} to #{new.inspect}."
+          end
+        end
+
+        if new_filter[:reject] != old_filter[:reject]
+          new = new_filter[:reject] || []
+          old = old_filter[:reject] || []
+          diff = new - old
+          if diff.length > 0
+            @errors << "#{old_resource[:name]}: filter #{name.inspect} blacklist went from #{old.inspect} to #{new.inspect}."
+          end
+        end
+
         if (diff = old_filter[:operators] - new_filter[:operators]).length > 0
           diff.each do |op|
             @errors << "#{old_resource[:name]}: filter #{name.inspect} removed operator #{op.inspect}."

--- a/lib/graphiti/sideload.rb
+++ b/lib/graphiti/sideload.rb
@@ -68,6 +68,7 @@ module Graphiti
     end
 
     def check!
+      return if scope_proc
       case type
       when :has_many, :has_one
         unless resource.filters[foreign_key]

--- a/lib/graphiti/util/link.rb
+++ b/lib/graphiti/util/link.rb
@@ -14,14 +14,33 @@ module Graphiti
       end
 
       def generate
-        if params.empty?
-          path
-        else
-          "#{path}?#{URI.unescape(params.to_query)}"
-        end
+        on_demand_links(raw_url)
       end
 
       private
+
+      def raw_url
+        if @sideload.link_proc
+          @sideload.link_proc.call(@model)
+        else
+          if params.empty?
+            path
+          else
+            "#{path}?#{URI.unescape(params.to_query)}"
+          end
+        end
+      end
+
+      def on_demand_links(url)
+        return url unless Graphiti.config.links_on_demand
+
+        if url.include?('?')
+          url << '&links=true'
+        else
+          url << '?links=true'
+        end
+        url
+      end
 
       def params
         @params ||= {}.tap do |params|

--- a/lib/graphiti/util/serializer_attributes.rb
+++ b/lib/graphiti/util/serializer_attributes.rb
@@ -66,10 +66,11 @@ module Graphiti
       end
 
       def wrap_proc(inner)
-        type_name = @attr[:type]
+        _resource = @resource.new
+        _name = @name
         ->(serializer_instance = nil) {
-          type = Graphiti::Types[type_name]
-          type[:read][serializer_instance.instance_eval(&inner)]
+           value = serializer_instance.instance_eval(&inner)
+          _resource.typecast(_name, value, :readable)
         }
       end
 

--- a/lib/graphiti/util/serializer_relationships.rb
+++ b/lib/graphiti/util/serializer_relationships.rb
@@ -44,11 +44,7 @@ module Graphiti
           proc do
             if @proxy.query.links?
               link(:related) do
-                if prc = sl.link_proc
-                  prc.call(@object)
-                else
-                  ::Graphiti::Util::Link.new(sl, @object).generate
-                end
+                ::Graphiti::Util::Link.new(sl, @object).generate
               end
             end
           end
@@ -75,7 +71,7 @@ module Graphiti
         action = sideload.type == :belongs_to ? :show : :index
         prc = Graphiti.config.context_for_endpoint
         unless prc.call(sideload.resource.endpoint[:full_path], action)
-          raise Errors::InvalidLink.new(@resource_class, sideload)
+          raise Errors::InvalidLink.new(@resource_class, sideload, action)
         end
       end
 

--- a/spec/fixtures/employee_directory.rb
+++ b/spec/fixtures/employee_directory.rb
@@ -126,7 +126,7 @@ class Salary < ApplicationRecord
 end
 
 class ApplicationResource < Graphiti::Resource
-  self.adapter = Graphiti::Adapters::ActiveRecord::Base.new
+  self.adapter = Graphiti::Adapters::ActiveRecord::Base
   self.abstract_class = true
 end
 

--- a/spec/fixtures/legacy.rb
+++ b/spec/fixtures/legacy.rb
@@ -155,7 +155,7 @@ module Legacy
   end
 
   class ApplicationResource < Graphiti::Resource
-    self.adapter = Graphiti::Adapters::ActiveRecord::Base.new
+    self.adapter = Graphiti::Adapters::ActiveRecord::Base
     self.abstract_class = true
   end
 
@@ -299,7 +299,7 @@ module Legacy
   end
 
   class AuthorSearchResource < ApplicationResource
-    self.adapter = SearchAdapter.new
+    self.adapter = SearchAdapter
     self.model = Legacy::Author
 
     has_many :special_books, resource: Legacy::BookResource

--- a/spec/fixtures/poro.rb
+++ b/spec/fixtures/poro.rb
@@ -273,7 +273,7 @@ module PORO
   end
 
   class ApplicationResource < Graphiti::Resource
-    self.adapter = Adapter.new
+    self.adapter = Adapter
     self.abstract_class = true
 
     def base_scope

--- a/spec/integration/rails/before_commit_spec.rb
+++ b/spec/integration/rails/before_commit_spec.rb
@@ -28,7 +28,7 @@ if ENV["APPRAISAL_INITIALIZED"]
 
     module IntegrationHooks
       class ApplicationResource < Graphiti::Resource
-        self.adapter = Graphiti::Adapters::ActiveRecord::Base.new
+        self.adapter = Graphiti::Adapters::ActiveRecord::Base
       end
 
       class DepartmentResource < ApplicationResource

--- a/spec/integration/rails/hooks_spec.rb
+++ b/spec/integration/rails/hooks_spec.rb
@@ -16,7 +16,7 @@ if ENV["APPRAISAL_INITIALIZED"]
 
     module IntegrationHooks
       class ApplicationResource < Graphiti::Resource
-        self.adapter = Graphiti::Adapters::ActiveRecord::Base.new
+        self.adapter = Graphiti::Adapters::ActiveRecord::Base
       end
 
       class BookResource < ApplicationResource

--- a/spec/persistence_spec.rb
+++ b/spec/persistence_spec.rb
@@ -381,7 +381,7 @@ RSpec.describe 'persistence' do
       context 'when cannot coerce' do
         it 'raises error' do
           expect {
-            save(nil)
+            save({})
           }.to raise_error(Graphiti::Errors::TypecastFailed)
         end
       end

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Graphiti::Resource do
       end
 
       it 'sets defaults' do
-        expect(klass.adapter.class.ancestors[0])
+        expect(klass.adapter.ancestors[0])
           .to eq(Graphiti::Adapters::Abstract)
         expect(klass.default_sort).to eq([])
         expect(klass.default_page_size).to eq(20)
@@ -55,7 +55,7 @@ RSpec.describe Graphiti::Resource do
       end
 
       it 'inherits defaults' do
-        expect(klass.adapter.class.ancestors[0])
+        expect(klass.adapter.ancestors[0])
           .to eq(Graphiti::Adapters::Abstract)
         expect(klass.default_sort).to eq([])
         expect(klass.default_page_size).to eq(20)
@@ -92,7 +92,7 @@ RSpec.describe Graphiti::Resource do
       context 'when overriding defaults' do
         let(:klass) do
           Class.new(app_resource) do
-            self.adapter = PORO::Adapter.new
+            self.adapter = PORO::Adapter
             self.default_sort = [{ name: :asc }]
             self.default_page_size = 4
             self.attributes_readable_by_default = false
@@ -105,7 +105,7 @@ RSpec.describe Graphiti::Resource do
         end
 
         it 'works' do
-          expect(klass.adapter.class).to eq(PORO::Adapter)
+          expect(klass.adapter).to eq(PORO::Adapter)
           expect(klass.default_sort).to eq([{ name: :asc }])
           expect(klass.default_page_size).to eq(4)
           expect(klass.attributes_readable_by_default).to eq(false)
@@ -233,7 +233,7 @@ RSpec.describe Graphiti::Resource do
       context 'when the superclass overrode defaults' do
         let(:klass1) do
           Class.new(app_resource) do
-            self.adapter = PORO::Adapter.new
+            self.adapter = PORO::Adapter
             self.default_sort = [{ name: :asc }]
             self.default_page_size = 4
             self.attributes_readable_by_default = false
@@ -246,7 +246,7 @@ RSpec.describe Graphiti::Resource do
         end
 
         it 'carries them over to the subclass' do
-          expect(klass2.adapter.class).to eq(PORO::Adapter)
+          expect(klass2.adapter).to eq(PORO::Adapter)
           expect(klass2.default_sort).to eq([{ name: :asc }])
           expect(klass2.default_page_size).to eq(4)
           expect(klass2.attributes_readable_by_default).to eq(false)
@@ -956,7 +956,7 @@ RSpec.describe Graphiti::Resource do
 
     before do
       klass.model = PORO::Employee
-      klass.adapter = adapter.new
+      klass.adapter = adapter
     end
 
     it 'delegates to the adapter' do
@@ -981,7 +981,7 @@ RSpec.describe Graphiti::Resource do
   describe 'query methods' do
     before do
       klass.class_eval do
-        self.adapter = PORO::Adapter.new
+        self.adapter = PORO::Adapter
         self.model = PORO::Employee
 
         stat total: [:count]
@@ -1289,7 +1289,7 @@ RSpec.describe Graphiti::Resource do
       context 'and the path is supported' do
         before do
           klass.class_eval do
-            self.adapter = PORO::Adapter.new
+            self.adapter = PORO::Adapter
             primary_endpoint '/api/v1/employees'
             self.model = PORO::Employee
             def base_scope
@@ -1429,6 +1429,16 @@ RSpec.describe Graphiti::Resource do
           expect(typecast).to eq(1)
         end
 
+        context 'but it is nil' do
+          let(:value) { nil }
+
+          it 'does not go through coercion' do
+            expect(Graphiti::Types[:integer])
+              .to_not receive(:[]).with(:read)
+            expect(typecast).to be_nil
+          end
+        end
+
         context 'when coercion fails' do
           let(:value) { {} }
 
@@ -1529,7 +1539,7 @@ RSpec.describe Graphiti::Resource do
   describe '#around_scoping' do
     before do
       klass.class_eval do
-        self.adapter = Graphiti::Adapters::Null.new
+        self.adapter = Graphiti::Adapters::Null
         attr_accessor :scope
 
         attribute :foo, :string

--- a/spec/schema_diff_spec.rb
+++ b/spec/schema_diff_spec.rb
@@ -353,6 +353,116 @@ RSpec.describe Graphiti::SchemaDiff do
       end
     end
 
+    context 'when filter goes single: true to single: false' do
+      before do
+        resource_b.filter :foo, :string
+        resource_a.filter :foo, :string, single: true
+      end
+
+      it { is_expected.to eq([]) }
+    end
+
+    context 'when filter goes single: false to single: true' do
+      before do
+        resource_b.filter :foo, :string, single: true
+        resource_a.filter :foo, :string
+      end
+
+      it 'returns error' do
+        expect(diff).to eq([
+          'SchemaDiff::EmployeeResource: filter :foo became singular.'
+        ])
+      end
+    end
+
+    context 'when filter adds to whitelist' do
+      before do
+        resource_b.filter :foo, :string, allow: ['foo', 'bar']
+        resource_a.filter :foo, :string, allow: ['foo']
+      end
+
+      it 'returns error' do
+        expect(diff).to eq([
+          'SchemaDiff::EmployeeResource: filter :foo whitelist went from ["foo"] to ["foo", "bar"].'
+        ])
+      end
+    end
+
+    context 'when filter removes from whitelist' do
+      before do
+        resource_b.filter :foo, :string, allow: ['foo']
+        resource_a.filter :foo, :string, allow: ['foo', 'bar']
+      end
+
+      it { is_expected.to eq([]) }
+    end
+
+    context 'when filter removes whitelist' do
+      before do
+        resource_b.filter :foo, :string
+        resource_a.filter :foo, :string, allow: ['foo']
+      end
+
+      it { is_expected.to eq([]) }
+    end
+
+    context 'when filter adds whitelist' do
+      before do
+        resource_b.filter :foo, :string, allow: ['foo']
+        resource_a.filter :foo, :string
+      end
+
+      it 'returns error' do
+        expect(diff).to eq([
+          'SchemaDiff::EmployeeResource: filter :foo whitelist went from [] to ["foo"].'
+        ])
+      end
+    end
+
+    context 'when filter adds to blacklist' do
+      before do
+        resource_b.filter :foo, :string, reject: ['foo', 'bar']
+        resource_a.filter :foo, :string, reject: ['foo']
+      end
+
+      it 'returns error' do
+        expect(diff).to eq([
+          'SchemaDiff::EmployeeResource: filter :foo blacklist went from ["foo"] to ["foo", "bar"].'
+        ])
+      end
+    end
+
+    context 'when filter removes from blacklist' do
+      before do
+        resource_b.filter :foo, :string, reject: ['foo']
+        resource_a.filter :foo, :string, reject: ['foo', 'bar']
+      end
+
+      it { is_expected.to eq([]) }
+    end
+
+    context 'when filter removes blacklist' do
+      before do
+        resource_b.filter :foo, :string
+        resource_a.filter :foo, :string, reject: ['foo']
+      end
+
+      it { is_expected.to eq([]) }
+    end
+
+    context 'when filter adds blacklist' do
+      before do
+        resource_b.filter :foo, :string, reject: ['foo']
+        resource_a.filter :foo, :string
+      end
+
+      it 'returns error' do
+        expect(diff).to eq([
+          'SchemaDiff::EmployeeResource: filter :foo blacklist went from [] to ["foo"].'
+        ])
+      end
+    end
+
     context 'when filter goes :required to not' do
       before do
         resource_b.filter :foo, :string
@@ -398,8 +508,6 @@ RSpec.describe Graphiti::SchemaDiff do
     end
 
     context 'when relationship is added' do
-
-
       before do
         resource_b.has_many :positions, resource: position_resource
       end

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -28,15 +28,15 @@ RSpec.describe Graphiti::Schema do
             filters: {
               id: {
                 type: 'integer_id',
-                operators: Graphiti::Adapters::Abstract.new.default_operators[:integer].map(&:to_s)
+                operators: Graphiti::Adapters::Abstract.default_operators[:integer].map(&:to_s)
               },
               first_name: {
                 type: 'string',
-                operators: Graphiti::Adapters::Abstract.new.default_operators[:string].map(&:to_s)
+                operators: Graphiti::Adapters::Abstract.default_operators[:string].map(&:to_s)
               },
               title: {
                 type: 'string',
-                operators: Graphiti::Adapters::Abstract.new.default_operators[:string].map(&:to_s)
+                operators: Graphiti::Adapters::Abstract.default_operators[:string].map(&:to_s)
               }
             },
             extra_attributes: {
@@ -348,6 +348,45 @@ RSpec.describe Graphiti::Schema do
             'match',
             'not_match'
           ])
+      end
+    end
+
+    context 'when the filter is singular' do
+      before do
+        employee_resource.class_eval do
+          filter :first_name, single: true
+        end
+      end
+
+      it 'is marked as such' do
+        expect(schema[:resources][0][:filters][:first_name][:single])
+          .to eq(true)
+      end
+    end
+
+    context 'when the filter has a whitelist' do
+      before do
+        employee_resource.class_eval do
+          filter :first_name, allow: ['foo']
+        end
+      end
+
+      it 'is marked as such' do
+        expect(schema[:resources][0][:filters][:first_name][:allow])
+          .to eq(['foo'])
+      end
+    end
+
+    context 'when the filter has a blacklist' do
+      before do
+        employee_resource.class_eval do
+          filter :first_name, reject: ['bar']
+        end
+      end
+
+      it 'is marked as such' do
+        expect(schema[:resources][0][:filters][:first_name][:reject])
+          .to eq(['bar'])
       end
     end
 

--- a/spec/serialization_spec.rb
+++ b/spec/serialization_spec.rb
@@ -777,6 +777,25 @@ RSpec.describe 'serialization' do
           expect(positions['links']['related'])
             .to eq('/special/positions?blah=1')
         end
+
+        context 'when links_on_demand' do
+          around do |e|
+            original = Graphiti.config.links_on_demand
+            begin
+              Graphiti.config.links_on_demand = true
+              e.run
+            ensure
+              Graphiti.config.links_on_demand = original
+            end
+          end
+
+          it 'adds links=true to url' do
+            params[:links] = true
+            render
+            expect(positions['links']['related'])
+              .to eq('/special/positions?blah=1&links=true')
+          end
+        end
       end
     end
 
@@ -809,6 +828,12 @@ RSpec.describe 'serialization' do
         it 'does render links' do
           render
           expect(positions).to have_key('links')
+        end
+
+        it 'appends ?links=true to link' do
+          render
+          expect(positions['links']['related'])
+            .to eq('/poro/positions?filter[employee_id]=1&links=true')
         end
       end
     end
@@ -869,7 +894,7 @@ RSpec.describe 'serialization' do
           it 'raises error' do
             expect {
               resource.has_many :positions
-            }.to raise_error(Graphiti::Errors::InvalidLink, /Make sure the endpoint \"\/poro\/positions\" exists/)
+            }.to raise_error(Graphiti::Errors::InvalidLink, /Make sure the endpoint \"\/poro\/positions\" exists with action :index/)
           end
         end
 
@@ -1010,7 +1035,7 @@ RSpec.describe 'serialization' do
           it 'raises error' do
             expect {
               resource.belongs_to :classification
-            }.to raise_error(Graphiti::Errors::InvalidLink, /Make sure the endpoint \"\/poro\/classifications\" exists/)
+            }.to raise_error(Graphiti::Errors::InvalidLink, /Make sure the endpoint \"\/poro\/classifications\" exists with action :show/)
           end
         end
 

--- a/spec/stats/dsl_spec.rb
+++ b/spec/stats/dsl_spec.rb
@@ -2,8 +2,9 @@ require 'spec_helper'
 
 RSpec.describe Graphiti::Stats::DSL do
   let(:config)   { :myattr }
-  let(:adapter)  { Graphiti::Adapters::Null.new }
+  let(:adapter)  { Graphiti::Adapters::Null.new(resource.new) }
   let(:instance) { described_class.new(adapter, config) }
+  let!(:resource) { Class.new(Graphiti::Resource) }
 
   describe '.new' do
     it 'sets name' do


### PR DESCRIPTION
* Adapters now accept a resource instance in their constructor. This
allows greater introspection/flexibility, and access to runtime context.
* Improved error messages
* Ability to pass `single: true` to `filter` for filters that can only
accept a single value. The yielded value will not be an array in this
case. Present in schema + backwards-compatibility checked. Booleans
default this to `true`.
* Ability to pass `allow` and `reject` to `filter`. This way we can
disallow filtering on `nil` (which can impact performance), accomodate
enums, and boolean filters that can only ever be `true`. Present in
schema + backwards-compatibility checked.
* If using on-demand links, ensure `links=true` is appended to all urls.
* Avoid typecasting `nil` when appropriate.