### PR TITLE
Bug fixes: ActiveRecord nils + required filters

### DIFF
--- a/lib/graphiti/adapters/abstract.rb
+++ b/lib/graphiti/adapters/abstract.rb
@@ -475,7 +475,6 @@ module Graphiti
       def activerecord_associate?(parent, child, association_name)
         defined?(::ActiveRecord) &&
           parent.is_a?(::ActiveRecord::Base) &&
-          child.is_a?(::ActiveRecord::Base) &&
           parent.class.reflect_on_association(association_name)
       end
     end

--- a/lib/graphiti/resource/dsl.rb
+++ b/lib/graphiti/resource/dsl.rb
@@ -15,12 +15,14 @@ module Graphiti
               opts[:single] = true
             end
 
+            required = att[:filterable] == :required || !!opts[:required]
             config[:filters][name.to_sym] = {
               aliases: aliases,
               type: att[:type],
               allow: opts[:allow],
               reject: opts[:reject],
               single: !!opts[:single],
+              required: required,
               operators: operators.to_hash
             }
           else

--- a/lib/graphiti/scoping/filterable.rb
+++ b/lib/graphiti/scoping/filterable.rb
@@ -24,8 +24,8 @@ module Graphiti
     end
 
     def required_attributes
-      resource.attributes.map do |k, v|
-        k if v[:filterable] == :required
+      resource.filters.map do |k, v|
+        k if v[:required]
       end.compact
     end
 

--- a/spec/filtering_spec.rb
+++ b/spec/filtering_spec.rb
@@ -960,7 +960,7 @@ RSpec.describe 'filtering' do
     end
   end
 
-  context 'when filter is guarded' do
+  context 'when filter is guarded via .attribute' do
     before do
       resource.class_eval do
         attribute :first_name, :string, filterable: :admin?
@@ -999,9 +999,35 @@ RSpec.describe 'filtering' do
     end
   end
 
-  context 'when filter is required' do
+  context 'when filter is required on .attribute' do
     before do
       resource.attribute :first_name, :string, filterable: :required
+    end
+
+    context 'and given in the request' do
+      before do
+        params[:filter] = { first_name: 'Agatha' }
+      end
+
+      it 'works' do
+        expect(records.map(&:id)).to eq([employee2.id])
+      end
+    end
+
+    context 'but not given in request' do
+      it 'raises error' do
+        expect {
+          records
+        }.to raise_error(Graphiti::Errors::RequiredFilter)
+      end
+    end
+  end
+
+  context 'when filter is required on .filter' do
+    before do
+      resource.config[:filters] = {}
+      resource.config[:attributes] = {}
+      resource.filter :first_name, :string, required: true
     end
 
     context 'and given in the request' do

--- a/spec/integration/rails/finders_spec.rb
+++ b/spec/integration/rails/finders_spec.rb
@@ -770,6 +770,19 @@ if ENV['APPRAISAL_INITIALIZED']
         expect(bio).to_not have_key('picture')
       end
 
+      context 'when no records found' do
+        before do
+          Legacy::Bio.delete_all
+        end
+
+        it 'still uses the activerecord adapter, not the PORO adapter' do
+          expect_any_instance_of(Legacy::Author).to_not receive(:bio=)
+          get :index, params: { include: 'bio' }
+          expect(json['data'][0]['relationships']['bio']['data'])
+            .to be_nil
+        end
+      end
+
       # Model/Resource has has_one, but it's just a subset of a has_many
       context 'when multiple records (faux-has_one)' do
         let!(:bio2) { Legacy::Bio.create!(author: author1, picture: 'imgur', description: 'author bio') }


### PR DESCRIPTION
We now allow `filter :foo, :string, required: true`, to match principle
of least surprise.

Fixed but where associating a nil would incorrectly use the PORO adapter
instead of Activerecord.