### PR TITLE
Improve serialization performance

### DIFF
--- a/lib/graphiti/resource.rb
+++ b/lib/graphiti/resource.rb
@@ -61,7 +61,7 @@ module Graphiti
     end
 
     def typecast(name, value, flag)
-      att = get_attr!(name, flag)
+      att = get_attr!(name, flag, request: true)
       type = Graphiti::Types[att[:type]]
       return if value.nil? && type[:kind] != 'array'
       begin

--- a/lib/graphiti/resource/configuration.rb
+++ b/lib/graphiti/resource/configuration.rb
@@ -185,6 +185,10 @@ module Graphiti
           attributes.merge(extra_attributes)
         end
 
+        def attribute_cache
+          @attribute_cache ||= all_attributes
+        end
+
         def sideloads
           config[:sideloads]
         end

--- a/lib/graphiti/util/attribute_check.rb
+++ b/lib/graphiti/util/attribute_check.rb
@@ -56,6 +56,10 @@ module Graphiti
           attribute[flag] != :required
       end
 
+      def cache?
+        !!@cache
+      end
+
       def error_class
         Errors::AttributeError
       end
@@ -64,8 +68,15 @@ module Graphiti
         attribute[flag] != false
       end
 
+      # If running in a request context, we've already loaded everything
+      # and there's no reason to perform logic, so go through attriubte cache
+      # Otherwise, this is a performance hit during typecasting
       def attribute
-        resource.all_attributes[name]
+        @attribute ||= if request?
+          resource.class.attribute_cache[name]
+        else
+          resource.all_attributes[name]
+        end
       end
 
       def attribute?


### PR DESCRIPTION
Go through memoized attributes, rather than merging hashes for every
attribute we render.