### PR TITLE
Introduce Graphiti::Serializer

### DIFF
--- a/lib/graphiti.rb
+++ b/lib/graphiti.rb
@@ -62,12 +62,11 @@ require "graphiti/util/serializer_attributes"
 require "graphiti/util/serializer_relationships"
 require "graphiti/util/class"
 require "graphiti/util/link"
-
 require 'graphiti/adapters/null'
-
 require "graphiti/extensions/extra_attribute"
 require "graphiti/extensions/boolean_attribute"
 require "graphiti/extensions/temp_id"
+require "graphiti/serializer"
 
 if defined?(ActiveRecord)
   require 'graphiti/adapters/active_record'

--- a/lib/graphiti/extensions/boolean_attribute.rb
+++ b/lib/graphiti/extensions/boolean_attribute.rb
@@ -27,7 +27,3 @@ module Graphiti
     end
   end
 end
-
-JSONAPI::Serializable::Resource.class_eval do
-  include Graphiti::Extensions::BooleanAttribute
-end

--- a/lib/graphiti/extensions/extra_attribute.rb
+++ b/lib/graphiti/extensions/extra_attribute.rb
@@ -24,7 +24,7 @@ module Graphiti
     #     end
     #   end
     #
-    #   class SerializablePerson < JSONAPI::Serializable::Resource
+    #   class SerializablePerson < Graphiti::Serializer
     #     # ... code ...
     #     extra_attribute :net_worth do
     #       @object.assets.sum(&:value)
@@ -56,15 +56,4 @@ module Graphiti
       end
     end
   end
-end
-
-JSONAPI::Serializable::Resource.class_eval do
-  def self.inherited(klass)
-    super
-    klass.class_eval do
-      extend JSONAPI::Serializable::Resource::ConditionalFields
-    end
-  end
-
-  include Graphiti::Extensions::ExtraAttribute
 end

--- a/lib/graphiti/extensions/temp_id.rb
+++ b/lib/graphiti/extensions/temp_id.rb
@@ -20,7 +20,3 @@ module Graphiti
     end
   end
 end
-
-JSONAPI::Serializable::Resource.class_eval do
-  prepend Graphiti::SerializableTempId
-end

--- a/lib/graphiti/hash_renderer.rb
+++ b/lib/graphiti/hash_renderer.rb
@@ -25,7 +25,6 @@ module Graphiti
       end
     end
   end
-  JSONAPI::Serializable::Resource.send(:include, SerializableHash)
 
   class HashRenderer
     def initialize(resource)

--- a/lib/graphiti/resource/configuration.rb
+++ b/lib/graphiti/resource/configuration.rb
@@ -134,7 +134,7 @@ module Graphiti
 
         # @api private
         def infer_serializer_superclass
-          serializer_class = JSONAPI::Serializable::Resource
+          serializer_class = ::Graphiti::Serializer
           namespace = Util::Class.namespace_for(self)
           app_serializer = "#{namespace}::ApplicationSerializer"
             .safe_constantize

--- a/lib/graphiti/serializer.rb
+++ b/lib/graphiti/serializer.rb
@@ -1,0 +1,30 @@
+module Graphiti
+  class Serializer < JSONAPI::Serializable::Resource
+    include Graphiti::Extensions::BooleanAttribute
+    include Graphiti::Extensions::ExtraAttribute
+    include Graphiti::SerializableHash
+    prepend Graphiti::SerializableTempId
+
+    def self.inherited(klass)
+      super
+      klass.class_eval do
+        extend JSONAPI::Serializable::Resource::ConditionalFields
+      end
+    end
+
+    # Temporary fix until fixed upstream
+    # https://github.com/jsonapi-rb/jsonapi-serializable/pull/102
+    def requested_relationships(fields)
+      @_relationships
+    end
+
+    # Allow access to resource methods
+    def method_missing(id, *args, &blk)
+      if @resource.respond_to?(id, true)
+        @resource.send(id, *args, &blk)
+      else
+        super
+      end
+    end
+  end
+end

--- a/spec/boolean_attribute_spec.rb
+++ b/spec/boolean_attribute_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 RSpec.describe '.boolean_attribute' do
   let(:klass) do
-    Class.new(JSONAPI::Serializable::Resource) do
-      type 'authors'
+    Class.new(Graphiti::Serializer) do
+      type :authors
 
       boolean_attribute :celebrity?
     end

--- a/spec/fixtures/legacy.rb
+++ b/spec/fixtures/legacy.rb
@@ -151,7 +151,7 @@ module Legacy
     #has_many :tags
   end
 
-  class LegacyApplicationSerializer < JSONAPI::Serializable::Resource
+  class LegacyApplicationSerializer < Graphiti::Serializer
   end
 
   class ApplicationResource < Graphiti::Resource

--- a/spec/fixtures/poro.rb
+++ b/spec/fixtures/poro.rb
@@ -269,7 +269,7 @@ module PORO
     end
   end
 
-  class EmployeeSerializer < JSONAPI::Serializable::Resource
+  class EmployeeSerializer < Graphiti::Serializer
     extra_attribute :stack_ranking do
       rand(999)
     end
@@ -381,6 +381,6 @@ module PORO
     end
   end
 
-  class ApplicationSerializer < JSONAPI::Serializable::Resource
+  class ApplicationSerializer < Graphiti::Serializer
   end
 end

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe Graphiti::Resource do
       end
 
       it 'infers serializer and type' do
-        expect(klass.serializer.ancestors[4])
-          .to eq(JSONAPI::Serializable::Resource)
+        expect(klass.serializer.ancestors[3])
+          .to eq(Graphiti::Serializer)
         # This class has no name
         expect(klass.type).to eq(:undefined_jsonapi_type)
       end
@@ -451,7 +451,7 @@ RSpec.describe Graphiti::Resource do
 
   describe '.serializer=' do
     let(:serializer) do
-      Class.new(JSONAPI::Serializable::Resource)
+      Class.new(Graphiti::Serializer)
     end
 
     it 'assigns the serializer class' do
@@ -745,7 +745,7 @@ RSpec.describe Graphiti::Resource do
 
     context 'when readable' do
       let(:serializer) do
-        Class.new(JSONAPI::Serializable::Resource)
+        Class.new(Graphiti::Serializer)
       end
 
       before do

--- a/spec/serialization_spec.rb
+++ b/spec/serialization_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'serialization' do
   context 'when serializer is automatically generated' do
     it 'generates a serializer class' do
       expect(resource.serializer.ancestors)
-        .to include(JSONAPI::Serializable::Resource)
+        .to include(Graphiti::Serializer)
     end
 
     it 'has same type as resource' do
@@ -46,7 +46,7 @@ RSpec.describe 'serialization' do
 
     describe 'helper functions' do
       let(:app_serializer) do
-        Class.new(JSONAPI::Serializable::Resource) do
+        Class.new(Graphiti::Serializer) do
           def my_method
             'bar!'
           end
@@ -107,7 +107,7 @@ RSpec.describe 'serialization' do
           end
         end
 
-        context 'but not a descendent of JSONAPI::Serializable::Resource' do
+        context 'but not a descendent of Graphiti::Serializer' do
           let(:app_serializer) { double.as_null_object }
 
           it 'cannot call methods on ApplicationSerializer' do
@@ -653,7 +653,7 @@ RSpec.describe 'serialization' do
 
     context 'when the resource has a different serializer than the model' do
       let(:serializer) do
-        Class.new(JSONAPI::Serializable::Resource) do
+        Class.new(Graphiti::Serializer) do
           attribute :first_name do
             'override'
           end
@@ -750,7 +750,7 @@ RSpec.describe 'serialization' do
   context 'when serializer is explicitly assigned' do
     it 'generates a serializer class' do
       expect(resource.serializer.ancestors)
-        .to include(JSONAPI::Serializable::Resource)
+        .to include(Graphiti::Serializer)
     end
 
     it 'has same type as resource' do


### PR DESCRIPTION
The main intent is to avoid specifying
`JSONAPI::Serializable::Resource`, which is a confusing superclass. But
this also gives us a place to stuff overrides, and mostly paves the way
for avoiding conflicts with raw usage.