### PR TITLE
Accomodate JSON, Array, escaped string params

### DIFF
--- a/lib/graphiti/context.rb
+++ b/lib/graphiti/context.rb
@@ -3,14 +3,14 @@ module Graphiti
     extend ActiveSupport::Concern
 
     module Overrides
-      def sideload_whitelist=(val)
+      def sideload_allowlist=(val)
         super(JSONAPI::IncludeDirective.new(val).to_hash)
       end
     end
 
     included do
-      class_attribute :sideload_whitelist
-      self.sideload_whitelist = {}
+      class_attribute :sideload_allowlist
+      self.sideload_allowlist = {}
       class << self;prepend Overrides;end
     end
   end

--- a/lib/graphiti/errors.rb
+++ b/lib/graphiti/errors.rb
@@ -36,16 +36,16 @@ Remove the single: true option to bypass this error.
     end
 
     class UnsupportedSort < Base
-      def initialize(resource, attribute, whitelist, direction)
+      def initialize(resource, attribute, allowlist, direction)
         @resource = resource
         @attribute = attribute
-        @whitelist = whitelist
+        @allowlist = allowlist
         @direction = direction
       end
 
       def message
         <<-MSG
-#{@resource.class.name}: tried to sort on attribute #{@attribute.inspect}, but passed #{@direction.inspect} when only #{@whitelist.inspect} is supported.
+#{@resource.class.name}: tried to sort on attribute #{@attribute.inspect}, but passed #{@direction.inspect} when only #{@allowlist.inspect} is supported.
         MSG
       end
     end
@@ -72,12 +72,12 @@ Remove the single: true option to bypass this error.
 
       def message
         allow = @filter.values[0][:allow]
-        reject = @filter.values[0][:reject]
+        deny = @filter.values[0][:deny]
         msg = <<-MSG
 #{@resource.class.name}: tried to filter on #{@filter.keys[0].inspect}, but passed invalid value #{@value.inspect}.
         MSG
-        msg << "\nWhitelist: #{allow.inspect}" if allow
-        msg << "\nBlacklist: #{reject.inspect}" if reject
+        msg << "\nAllowlist: #{allow.inspect}" if allow
+        msg << "\nDenylist: #{deny.inspect}" if deny
         msg
       end
     end
@@ -189,6 +189,19 @@ Graphiti.config.context_for_endpoint = ->(path, action) { ... }
           msg << ", but could not find an attribute with that name."
         end
         msg
+      end
+    end
+
+    class InvalidJSONArray < Base
+      def initialize(resource, value)
+        @resource = resource
+        @value = value
+      end
+
+      def message
+        <<-MSG
+#{@resource.class.name}: passed filter with value #{@value.inspect}, and failed attempting to parse as JSON array.
+        MSG
       end
     end
 

--- a/lib/graphiti/query.rb
+++ b/lib/graphiti/query.rb
@@ -156,13 +156,13 @@ module Graphiti
       @include_hash ||= begin
         requested = include_directive.to_hash
 
-        whitelist = nil
-        if @resource.context && @resource.context.respond_to?(:sideload_whitelist)
-          whitelist = @resource.context.sideload_whitelist
-          whitelist = whitelist[@resource.context_namespace] if whitelist
+        allowlist = nil
+        if @resource.context && @resource.context.respond_to?(:sideload_allowlist)
+          allowlist = @resource.context.sideload_allowlist
+          allowlist = allowlist[@resource.context_namespace] if allowlist
         end
 
-        whitelist ? Util::IncludeParams.scrub(requested, whitelist) : requested
+        allowlist ? Util::IncludeParams.scrub(requested, allowlist) : requested
       end
 
       @include_hash

--- a/lib/graphiti/resource.rb
+++ b/lib/graphiti/resource.rb
@@ -62,7 +62,11 @@ module Graphiti
 
     def typecast(name, value, flag)
       att = get_attr!(name, flag, request: true)
-      type = Graphiti::Types[att[:type]]
+      type_name = att[:type]
+      if flag == :filterable
+        type_name = filters[name][:type]
+      end
+      type = Graphiti::Types[type_name]
       return if value.nil? && type[:kind] != 'array'
       begin
         flag = :read if flag == :readable

--- a/lib/graphiti/resource/dsl.rb
+++ b/lib/graphiti/resource/dsl.rb
@@ -6,6 +6,7 @@ module Graphiti
       class_methods do
         def filter(name, *args, &blk)
           opts = args.extract_options!
+          type_override = args[0]
 
           if att = get_attr(name, :filterable, raise_error: :only_unsupported)
             aliases = [name, opts[:aliases]].flatten.compact
@@ -19,9 +20,9 @@ module Graphiti
             config[:filters][name.to_sym] = {
               aliases: aliases,
               name: name.to_sym,
-              type: att[:type],
+              type: type_override || att[:type],
               allow: opts[:allow],
-              reject: opts[:reject],
+              deny: opts[:deny],
               single: !!opts[:single],
               dependencies: opts[:dependent],
               required: required,

--- a/lib/graphiti/schema.rb
+++ b/lib/graphiti/schema.rb
@@ -57,9 +57,9 @@ module Graphiti
               end
 
               actions[a] = { resource: r.name }
-              if whitelist = ctx.sideload_whitelist
-                if whitelist[a]
-                  actions[a].merge!(sideload_whitelist: whitelist[a])
+              if allowlist = ctx.sideload_allowlist
+                if allowlist[a]
+                  actions[a].merge!(sideload_allowlist: allowlist[a])
                 end
               end
             end
@@ -165,7 +165,7 @@ module Graphiti
 
           config[:single] = true if filter[:single]
           config[:allow] = filter[:allow].map(&:to_s) if filter[:allow]
-          config[:reject] = filter[:reject].map(&:to_s) if filter[:reject]
+          config[:deny] = filter[:deny].map(&:to_s) if filter[:deny]
           config[:dependencies] = filter[:dependencies].map(&:to_s) if filter[:dependencies]
 
           attr = resource.attributes[name]

--- a/lib/graphiti/schema_diff.rb
+++ b/lib/graphiti/schema_diff.rb
@@ -173,16 +173,16 @@ module Graphiti
           old = old_filter[:allow] || []
           diff = new - old
           if diff.length > 0
-            @errors << "#{old_resource[:name]}: filter #{name.inspect} whitelist went from #{old.inspect} to #{new.inspect}."
+            @errors << "#{old_resource[:name]}: filter #{name.inspect} allowlist went from #{old.inspect} to #{new.inspect}."
           end
         end
 
-        if new_filter[:reject] != old_filter[:reject]
-          new = new_filter[:reject] || []
-          old = old_filter[:reject] || []
+        if new_filter[:deny] != old_filter[:deny]
+          new = new_filter[:deny] || []
+          old = old_filter[:deny] || []
           diff = new - old
           if diff.length > 0
-            @errors << "#{old_resource[:name]}: filter #{name.inspect} blacklist went from #{old.inspect} to #{new.inspect}."
+            @errors << "#{old_resource[:name]}: filter #{name.inspect} denylist went from #{old.inspect} to #{new.inspect}."
           end
         end
 
@@ -215,16 +215,16 @@ module Graphiti
             next
           end
 
-          if new_action[:sideload_whitelist] && !old_action[:sideload_whitelist]
-            @errors << "Endpoint \"#{path}\" added sideload whitelist."
+          if new_action[:sideload_allowlist] && !old_action[:sideload_allowlist]
+            @errors << "Endpoint \"#{path}\" added sideload allowlist."
           end
 
-          if new_action[:sideload_whitelist]
-            if new_action[:sideload_whitelist] != old_action[:sideload_whitelist]
+          if new_action[:sideload_allowlist]
+            if new_action[:sideload_allowlist] != old_action[:sideload_allowlist]
               removal = Util::Hash.include_removed? \
-                new_action[:sideload_whitelist], old_action[:sideload_whitelist]
+                new_action[:sideload_allowlist], old_action[:sideload_allowlist]
               if removal
-                @errors << "Endpoint \"#{path}\" had incompatible sideload whitelist. Was #{old_action[:sideload_whitelist].inspect}, now #{new_action[:sideload_whitelist].inspect}."
+                @errors << "Endpoint \"#{path}\" had incompatible sideload allowlist. Was #{old_action[:sideload_allowlist].inspect}, now #{new_action[:sideload_allowlist].inspect}."
               end
             end
           end

--- a/lib/graphiti/scoping/filter.rb
+++ b/lib/graphiti/scoping/filter.rb
@@ -1,12 +1,12 @@
 module Graphiti
   # Apply filtering logic to the scope
   #
-  # If the user requests to filter a field that has not been whitelisted,
+  # If the user requests to filter a field that has not been allowlisted,
   # a +Graphiti::Errors::BadFilter+ error will be raised.
   #
-  #   allow_filter :title # :title now whitelisted
+  #   allow_filter :title # :title now allowlisted
   #
-  # If the user requests a filter field that has been whitelisted, but
+  # If the user requests a filter field that has been allowlisted, but
   # does not pass the associated `+:if+ clause, +BadFilter+ will be raised.
   #
   #   allow_filter :title, if: :admin?
@@ -72,39 +72,19 @@ module Graphiti
     def each_filter
       filter_param.each_pair do |param_name, param_value|
         filter = find_filter!(param_name)
-        param_value = { eq: param_value } unless param_value.is_a?(Hash)
-        value = param_value.values.first
-        operator = param_value.keys.first
-        value = param_value.values.first unless filter.values[0][:type] == :hash
-        value = value.split(',') if value.is_a?(String) && value.include?(',')
-
-        if filter.values[0][:single] && value.is_a?(Array)
-          raise Errors::SingularFilter.new(resource, filter, value)
-        end
-
-        value = coerce_types(param_name.to_sym, value)
-
-        value.each do |v|
-          if allow = filter.values[0][:allow]
-            unless allow.include?(v)
-              raise Errors::InvalidFilterValue.new(resource, filter, value)
-            end
-          end
-
-          if reject = filter.values[0][:reject]
-            if reject.include?(v)
-              raise Errors::InvalidFilterValue.new(resource, filter, value)
-            end
-          end
-        end
-
+        value, operator = normalize_param(filter, param_value)
+        value  = parse_string_value(filter.values[0], value) if value.is_a?(String)
+        validate_singular(resource, filter, value)
+        value = coerce_types(filter.values[0], param_name.to_sym, value)
+        validate_allowlist(resource, filter, value)
+        validate_denylist(resource, filter, value)
         value = value[0] if filter.values[0][:single]
         yield filter, operator, value
       end
     end
 
-    def coerce_types(name, value)
-      type_name = @resource.all_attributes[name][:type]
+    def coerce_types(filter, name, value)
+      type_name = filter[:type]
       is_array = type_name.to_s.starts_with?('array_of') ||
         Types[type_name][:canonical_name] == :array
 
@@ -114,6 +94,99 @@ module Graphiti
         value = value.nil? || value.is_a?(Hash) ? [value] : Array(value)
         value.map { |v| @resource.typecast(name, v, :filterable) }
       end
+    end
+
+    def normalize_param(filter, param_value)
+      param_value = { eq: param_value } unless param_value.is_a?(Hash)
+      value = param_value.values.first
+      operator = param_value.keys.first
+
+      if filter.values[0][:type] == :hash
+        value, operator = \
+          parse_hash_value(filter, param_value, value, operator)
+      else
+        value = param_value.values.first
+      end
+
+      [value, operator]
+    end
+
+    def validate_singular(resource, filter, value)
+      if filter.values[0][:single] && value.is_a?(Array)
+        raise Errors::SingularFilter.new(resource, filter, value)
+      end
+    end
+
+    def validate_allowlist(resource, filter, values)
+      values.each do |v|
+        if allow = filter.values[0][:allow]
+          unless allow.include?(v)
+            raise Errors::InvalidFilterValue.new(resource, filter, v)
+          end
+        end
+      end
+    end
+
+    def validate_denylist(resource, filter, values)
+      values.each do |v|
+        if deny = filter.values[0][:deny]
+          if deny.include?(v)
+            raise Errors::InvalidFilterValue.new(resource, filter, v)
+          end
+        end
+      end
+    end
+
+    def parse_hash_value(filter, param_value, value, operator)
+      if operator != :eq
+        operator = :eq
+        value = param_value
+      end
+
+      if value.is_a?(String)
+        value = value.gsub('{{{', '{').gsub('}}}', '}')
+      end
+
+      [value, operator]
+    end
+
+    # foo,bar,baz becomes ["foo", "bar", "baz"] (unless array type)
+    # {{foo}} becomes ["foo"]
+    # {{foo,bar}},baz becomes ["foo,bar", "baz"]
+    #
+    # JSON of
+    # {{{ "id": 1 }}} becomes { 'id' => 1 }
+    def parse_string_value(filter, value)
+      type = Graphiti::Types[filter[:type]]
+      array_or_string = [:string, :array].include?(type[:canonical_name])
+      if (arr = value.scan(/\[.*?\]/)).present? && array_or_string
+        value = arr.map do |json|
+          begin
+            JSON.parse(json)
+          rescue
+            raise Errors::InvalidJSONArray.new(resource, value)
+          end
+        end
+        value = value[0] if value.length == 1
+      else
+        value = parse_string_arrays(value)
+      end
+      value
+    end
+
+    def parse_string_arrays(value)
+      # Find the quoted strings
+      quotes = value.scan(/{{.*?}}/)
+      # remove them from the rest
+      quotes.each { |q| value.gsub!(q, '') }
+      # remove the quote characters from the quoted strings
+      quotes.each { |q| q.gsub!('{{', '').gsub!('}}', '') }
+      # merge everything back together into an array
+      value = Array(value.split(',')) + quotes
+      # remove any blanks that are left
+      value.reject! { |v| v.length.zero? }
+      value = value[0] if value.length == 1
+      value
     end
   end
 end

--- a/lib/graphiti/types.rb
+++ b/lib/graphiti/types.rb
@@ -69,7 +69,8 @@ module Graphiti
     end
 
     PresentParamsHash = create(::Hash) do |input|
-      Dry::Types['params.hash'][input].deep_symbolize_keys
+      input = JSON.parse(input) if input.is_a?(String)
+      Dry::Types['params.hash'][input]
     end
 
     REQUIRED_KEYS = [:params, :read, :write, :kind, :description]

--- a/lib/graphiti/util/include_params.rb
+++ b/lib/graphiti/util/include_params.rb
@@ -9,7 +9,7 @@ module Graphiti
         #
         # But our resource had this code:
         #
-        #   sideload_whitelist({ index: [:comments] })
+        #   sideload_allowlist({ index: [:comments] })
         #
         # We should drop the 'author' sideload from the request.
         #

--- a/spec/integration/rails/finders_spec.rb
+++ b/spec/integration/rails/finders_spec.rb
@@ -71,7 +71,7 @@ if ENV['APPRAISAL_INITIALIZED']
       expect(d.map(&:id)).to eq([author2.id])
     end
 
-    it 'allows whitelisted filters (and other configs)' do
+    it 'allows allowlisted filters (and other configs)' do
       get :index, params: { filter: { first_name: 'George' } }
       expect(d.map(&:id)).to eq([author2.id])
     end

--- a/spec/integration/rails/sideload_allowlist_spec.rb
+++ b/spec/integration/rails/sideload_allowlist_spec.rb
@@ -1,5 +1,5 @@
 if ENV["APPRAISAL_INITIALIZED"]
-  RSpec.describe 'sideload whitelist', type: :controller do
+  RSpec.describe 'sideload allowlist', type: :controller do
     controller(ApplicationController) do
       def index
         render jsonapi: Legacy::AuthorResource.all(params)
@@ -27,7 +27,7 @@ if ENV["APPRAISAL_INITIALIZED"]
 
     let(:path) { '/legacy/authors' }
 
-    context 'when no sideload whitelist' do
+    context 'when no sideload allowlist' do
       it 'allows loading all relationships' do
         get :index, params: { include: 'books.genre' }
         expect(json_includes('books')).to_not be_blank
@@ -35,9 +35,9 @@ if ENV["APPRAISAL_INITIALIZED"]
       end
     end
 
-    context 'when a sideload whitelist' do
+    context 'when a sideload allowlist' do
       before do
-        controller.class.sideload_whitelist = {
+        controller.class.sideload_allowlist = {
           index: [:books],
           show: { books: :genre }
         }

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe Graphiti::Query do
         end
       end
 
-      context 'when context has sideload whitelist' do
+      context 'when context has sideload allowlist' do
         let(:ctx) do
-          OpenStruct.new(sideload_whitelist: { update: { positions: {} }})
+          OpenStruct.new(sideload_allowlist: { update: { positions: {} }})
         end
 
         around do |e|
@@ -63,7 +63,7 @@ RSpec.describe Graphiti::Query do
         end
       end
 
-      context 'when context does not respond to #sideload_whitelist' do
+      context 'when context does not respond to #sideload_allowlist' do
         before do
           params[:include] = 'positions.department'
         end

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -442,7 +442,7 @@ RSpec.describe Graphiti::Resource do
         .to match_array([:positions, :department])
     end
 
-    context 'when no whitelist' do
+    context 'when no allowlist' do
       it 'defaults to empty array' do
         expect(klass.association_names).to eq([])
       end
@@ -1561,6 +1561,18 @@ RSpec.describe Graphiti::Resource do
         expect(Graphiti::Types[:integer])
           .to receive(:[]).with(:params).and_call_original
         expect(typecast).to eq(1)
+      end
+
+      context 'and filter overrides type' do
+        before do
+          klass.filter :foo, :string
+        end
+
+        it 'uses the filter type' do
+          expect(Graphiti::Types[:string])
+            .to receive(:[]).with(:params).and_call_original
+          expect(typecast).to eq('1')
+        end
       end
 
       context 'when coercion fails' do

--- a/spec/schema_diff_spec.rb
+++ b/spec/schema_diff_spec.rb
@@ -571,7 +571,7 @@ RSpec.describe Graphiti::SchemaDiff do
       end
     end
 
-    context 'when filter adds to whitelist' do
+    context 'when filter adds to allowlist' do
       before do
         resource_b.filter :foo, :string, allow: ['foo', 'bar']
         resource_a.filter :foo, :string, allow: ['foo']
@@ -579,12 +579,12 @@ RSpec.describe Graphiti::SchemaDiff do
 
       it 'returns error' do
         expect(diff).to eq([
-          'SchemaDiff::EmployeeResource: filter :foo whitelist went from ["foo"] to ["foo", "bar"].'
+          'SchemaDiff::EmployeeResource: filter :foo allowlist went from ["foo"] to ["foo", "bar"].'
         ])
       end
     end
 
-    context 'when filter removes from whitelist' do
+    context 'when filter removes from allowlist' do
       before do
         resource_b.filter :foo, :string, allow: ['foo']
         resource_a.filter :foo, :string, allow: ['foo', 'bar']
@@ -593,7 +593,7 @@ RSpec.describe Graphiti::SchemaDiff do
       it { is_expected.to eq([]) }
     end
 
-    context 'when filter removes whitelist' do
+    context 'when filter removes allowlist' do
       before do
         resource_b.filter :foo, :string
         resource_a.filter :foo, :string, allow: ['foo']
@@ -602,7 +602,7 @@ RSpec.describe Graphiti::SchemaDiff do
       it { is_expected.to eq([]) }
     end
 
-    context 'when filter adds whitelist' do
+    context 'when filter adds allowlist' do
       before do
         resource_b.filter :foo, :string, allow: ['foo']
         resource_a.filter :foo, :string
@@ -610,51 +610,51 @@ RSpec.describe Graphiti::SchemaDiff do
 
       it 'returns error' do
         expect(diff).to eq([
-          'SchemaDiff::EmployeeResource: filter :foo whitelist went from [] to ["foo"].'
+          'SchemaDiff::EmployeeResource: filter :foo allowlist went from [] to ["foo"].'
         ])
       end
     end
 
-    context 'when filter adds to blacklist' do
+    context 'when filter adds to denylist' do
       before do
-        resource_b.filter :foo, :string, reject: ['foo', 'bar']
-        resource_a.filter :foo, :string, reject: ['foo']
+        resource_b.filter :foo, :string, deny: ['foo', 'bar']
+        resource_a.filter :foo, :string, deny: ['foo']
       end
 
       it 'returns error' do
         expect(diff).to eq([
-          'SchemaDiff::EmployeeResource: filter :foo blacklist went from ["foo"] to ["foo", "bar"].'
+          'SchemaDiff::EmployeeResource: filter :foo denylist went from ["foo"] to ["foo", "bar"].'
         ])
       end
     end
 
-    context 'when filter removes from blacklist' do
+    context 'when filter removes from denylist' do
       before do
-        resource_b.filter :foo, :string, reject: ['foo']
-        resource_a.filter :foo, :string, reject: ['foo', 'bar']
+        resource_b.filter :foo, :string, deny: ['foo']
+        resource_a.filter :foo, :string, deny: ['foo', 'bar']
       end
 
       it { is_expected.to eq([]) }
     end
 
-    context 'when filter removes blacklist' do
+    context 'when filter removes denylist' do
       before do
         resource_b.filter :foo, :string
-        resource_a.filter :foo, :string, reject: ['foo']
+        resource_a.filter :foo, :string, deny: ['foo']
       end
 
       it { is_expected.to eq([]) }
     end
 
-    context 'when filter adds blacklist' do
+    context 'when filter adds denylist' do
       before do
-        resource_b.filter :foo, :string, reject: ['foo']
+        resource_b.filter :foo, :string, deny: ['foo']
         resource_a.filter :foo, :string
       end
 
       it 'returns error' do
         expect(diff).to eq([
-          'SchemaDiff::EmployeeResource: filter :foo blacklist went from [] to ["foo"].'
+          'SchemaDiff::EmployeeResource: filter :foo denylist went from [] to ["foo"].'
         ])
       end
     end
@@ -937,41 +937,41 @@ RSpec.describe Graphiti::SchemaDiff do
       end
     end
 
-    context 'when an endpoint action sideload whitelist is added' do
+    context 'when an endpoint action sideload allowlist is added' do
       before do
         a
-        test_context.sideload_whitelist = { index: [:positions] }
+        test_context.sideload_allowlist = { index: [:positions] }
       end
 
       it 'returns error' do
         expect(diff).to eq([
-          'Endpoint "/schema_diff/employees" added sideload whitelist.'
+          'Endpoint "/schema_diff/employees" added sideload allowlist.'
         ])
       end
     end
 
-    context 'when an endpoint action sideload whitelist is removed' do
+    context 'when an endpoint action sideload allowlist is removed' do
       before do
-        test_context.sideload_whitelist = { index: [:positions] }
+        test_context.sideload_allowlist = { index: [:positions] }
         a
-        test_context.sideload_whitelist = nil
+        test_context.sideload_allowlist = nil
       end
 
       it 'returns true' do
-        expect(a[:endpoints].values[0][:actions][:index][:sideload_whitelist])
+        expect(a[:endpoints].values[0][:actions][:index][:sideload_allowlist])
           .to eq([:positions])
         expect(diff).to eq([])
       end
     end
 
-    context 'when an endpoint action sideload whitelist changes' do
+    context 'when an endpoint action sideload allowlist changes' do
       context 'with an addition' do
         before do
-          test_context.sideload_whitelist = {
+          test_context.sideload_allowlist = {
             index: [:positions]
           }
           a
-          test_context.sideload_whitelist = { index: { positions: :department } }
+          test_context.sideload_allowlist = { index: { positions: :department } }
         end
 
         it { is_expected.to eq([]) }
@@ -979,25 +979,25 @@ RSpec.describe Graphiti::SchemaDiff do
 
       context 'with a removal' do
         before do
-          test_context.sideload_whitelist = {
+          test_context.sideload_allowlist = {
             index: [
               { positions: :department },
               :same
             ]
           }
           a
-          test_context.sideload_whitelist = { index: [:positions, :same] }
+          test_context.sideload_allowlist = { index: [:positions, :same] }
         end
 
         it 'returns error' do
           expect(diff).to eq([
-            'Endpoint "/schema_diff/employees" had incompatible sideload whitelist. Was [{:positions=>:department}, :same], now [:positions, :same].'
+            'Endpoint "/schema_diff/employees" had incompatible sideload allowlist. Was [{:positions=>:department}, :same], now [:positions, :same].'
           ])
         end
       end
     end
 
-    context 'when an endpoint action write attribute whitelist changes' do
+    context 'when an endpoint action write attribute allowlist changes' do
       xit 'todo' do
       end
     end

--- a/spec/schema_spec.rb
+++ b/spec/schema_spec.rb
@@ -298,6 +298,19 @@ RSpec.describe Graphiti::Schema do
       end
     end
 
+    context 'when filter overrides type' do
+      before do
+        employee_resource.filter :first_name, :integer
+      end
+
+      it 'is reflected in the schema' do
+        expect(schema[:resources][0][:attributes][:first_name][:type])
+          .to eq('string')
+        expect(schema[:resources][0][:filters][:first_name][:type])
+          .to eq('integer')
+      end
+    end
+
     context 'when the filter is guarded' do
       before do
         employee_resource.class_eval do
@@ -376,7 +389,7 @@ RSpec.describe Graphiti::Schema do
       end
     end
 
-    context 'when the filter has a whitelist' do
+    context 'when the filter has a allowlist' do
       before do
         employee_resource.class_eval do
           filter :first_name, allow: [:foo]
@@ -389,15 +402,15 @@ RSpec.describe Graphiti::Schema do
       end
     end
 
-    context 'when the filter has a blacklist' do
+    context 'when the filter has a denylist' do
       before do
         employee_resource.class_eval do
-          filter :first_name, reject: [:bar]
+          filter :first_name, deny: [:bar]
         end
       end
 
       it 'is marked as such' do
-        expect(schema[:resources][0][:filters][:first_name][:reject])
+        expect(schema[:resources][0][:filters][:first_name][:deny])
           .to eq(['bar'])
       end
     end
@@ -460,16 +473,16 @@ RSpec.describe Graphiti::Schema do
       end
     end
 
-    context 'when sideload whitelist' do
+    context 'when sideload allowlist' do
       before do
-        test_context.sideload_whitelist = {
+        test_context.sideload_allowlist = {
           index: { positions: 'department' }
         }
       end
 
       it 'is reflected in the schema' do
         endpoint = schema[:endpoints][:"/api/v1/schema/employees"]
-        expect(endpoint[:actions][:index][:sideload_whitelist]).to eq({
+        expect(endpoint[:actions][:index][:sideload_allowlist]).to eq({
           positions: { department: {} }
         })
       end


### PR DESCRIPTION
* The type `hash` can now be queried with a string of JSON, and will get
converted to a ruby hash.
* The type `array` can now pass a JSON array in the query string.
* Strings with special characters/commas can now be wrapped in
{{curlies}} to be treated straight-up.
* If an attribute exists, but a filter defines a different type, the
filter type will now be honored when filtering.

See specs for more.