### PR TITLE
Improve serialization typechecking performance

### DIFF
--- a/lib/graphiti/resource/configuration.rb
+++ b/lib/graphiti/resource/configuration.rb
@@ -185,10 +185,6 @@ module Graphiti
           attributes.merge(extra_attributes)
         end
 
-        def attribute_cache
-          @attribute_cache ||= all_attributes
-        end
-
         def sideloads
           config[:sideloads]
         end

--- a/lib/graphiti/util/attribute_check.rb
+++ b/lib/graphiti/util/attribute_check.rb
@@ -56,10 +56,6 @@ module Graphiti
           attribute[flag] != :required
       end
 
-      def cache?
-        !!@cache
-      end
-
       def error_class
         Errors::AttributeError
       end
@@ -68,15 +64,8 @@ module Graphiti
         attribute[flag] != false
       end
 
-      # If running in a request context, we've already loaded everything
-      # and there's no reason to perform logic, so go through attriubte cache
-      # Otherwise, this is a performance hit during typecasting
       def attribute
-        @attribute ||= if request?
-          resource.class.attribute_cache[name]
-        else
-          resource.all_attributes[name]
-        end
+        @attribute ||= resource.all_attributes[name]
       end
 
       def attribute?


### PR DESCRIPTION
This was causing a hit to look up the attribute/type and perform the
logic. But we actually don't need that heavier-weight method for
serialization. The guard has already been run, and we already have the
type at definition-time. So, instead, register the serialization proc
with the type itself, rather than performing a runtime
lookup/validation.