### PR TITLE
Accomodate re-rendering same entity

### DIFF
--- a/lib/graphiti/jsonapi_serializable_ext.rb
+++ b/lib/graphiti/jsonapi_serializable_ext.rb
@@ -35,25 +35,6 @@ module Graphiti
       end
     end
 
-    # Temporary fix until fixed upstream
-    # https://github.com/jsonapi-rb/jsonapi-serializable/pull/102
-    module ResourceOverrides
-      def requested_relationships(fields)
-        @_relationships
-      end
-
-      # Allow access to resource methods
-      def method_missing(id, *args, &blk)
-        if @resource.respond_to?(id, true)
-          @resource.send(id, *args, &blk)
-        else
-          super
-        end
-      end
-    end
-
-    JSONAPI::Serializable::Resource
-      .send(:prepend, ResourceOverrides)
     JSONAPI::Serializable::Relationship
       .send(:prepend, RelationshipOverrides)
     JSONAPI::Serializable::Renderer

--- a/lib/graphiti/resource.rb
+++ b/lib/graphiti/resource.rb
@@ -25,9 +25,11 @@ module Graphiti
     end
 
     def decorate_record(record)
-      serializer = serializer_for(record)
-      record.instance_variable_set(:@__graphiti_serializer, serializer)
-      record.instance_variable_set(:@__graphiti_resource, self)
+      unless record.instance_variable_get(:@__graphiti_serializer)
+        serializer = serializer_for(record)
+        record.instance_variable_set(:@__graphiti_serializer, serializer)
+        record.instance_variable_set(:@__graphiti_resource, self)
+      end
     end
 
     def with_context(object, namespace = nil)

--- a/spec/fixtures/poro.rb
+++ b/spec/fixtures/poro.rb
@@ -135,6 +135,7 @@ module PORO
       :age,
       :active,
       :positions,
+      :current_position,
       :bio,
       :teams,
       :classification,


### PR DESCRIPTION
A given resource identifier should only appear once in the payload.
However, you might be loading that object at different levels of the
graph, with different associations:

`/employees?include=current_position.department,positions`

In this case, Position ID 1 should correctly only be in the payload
once. However, we need to make sure the department relationship is
rendered.

This exposes an existing issue in jsonapi-rb: because we're only
rendering the object once, the `current_position` has the `department`
eager-loaded, while the same record in `positions` does not.

Pre-graphiti, models associated to serializers. So `position.department`
would be called, causing an extra query. With Graphiti, resources are
associated to serializers, and associated to models at runtime. This has
the effect of raising an error - `position.department` fires, a new
`Department` instance is returned that does not have an associated
resource/serializer, and we blow up.

Accomodating this in serialization would be a heavy-weight rewrite (see
https://github.com/jsonapi-rb/jsonapi-renderer/blob/master/lib/jsonapi/renderer/resources_processor.rb#L47-L55).

Instead, we accept the existing behavior of an extra query, but ensure
that relationship data always gets a serializer assigned regardless of
how it was fetched. This is the extension to
`util/serializater_relationships` data proc: grab the data, then
decorate it.