### PR TITLE
Ensure attributes don't get excessively wrapped

### DIFF
--- a/lib/graphiti/serializer.rb
+++ b/lib/graphiti/serializer.rb
@@ -5,6 +5,16 @@ module Graphiti
     include Graphiti::SerializableHash
     prepend Graphiti::SerializableTempId
 
+    # Keep track of what attributes have been applied by the Resource,
+    # via .attribute, and which have been applied by a custom serializer
+    # class/file.
+    # This way, we can ensure attributes NOT applied by a resource still
+    # go through type checking/coercion
+    class_attribute :attributes_applied_via_resource
+    class_attribute :extra_attributes_applied_via_resource
+    self.attributes_applied_via_resource = []
+    self.extra_attributes_applied_via_resource = []
+
     def self.inherited(klass)
       super
       klass.class_eval do

--- a/lib/graphiti/util/serializer_attributes.rb
+++ b/lib/graphiti/util/serializer_attributes.rb
@@ -20,14 +20,27 @@ module Graphiti
           if @serializer.attribute_blocks[@name].nil?
             @serializer.send(_method, @name, serializer_options, &proc)
           else
-            inner = @serializer.attribute_blocks.delete(@name)
-            wrapped = wrap_proc(inner)
-            @serializer.send(_method, @name, serializer_options, &wrapped)
+            unless @serializer.send(applied_method).include?(@name)
+              inner = @serializer.attribute_blocks.delete(@name)
+              wrapped = wrap_proc(inner)
+              @serializer.send(_method, @name, serializer_options, &wrapped)
+            end
           end
         end
+
+        existing = @serializer.send(applied_method)
+        @serializer.send(:"#{applied_method}=", [@name] | existing)
       end
 
       private
+
+      def applied_method
+        if extra?
+          :extra_attributes_applied_via_resource
+        else
+          :attributes_applied_via_resource
+        end
+      end
 
       def _method
         extra? ? :extra_attribute : :attribute

--- a/spec/fixtures/poro.rb
+++ b/spec/fixtures/poro.rb
@@ -143,7 +143,8 @@ module PORO
       :credit_card,
       :credit_card_id,
       :cc_id,
-      :credit_card_type
+      :credit_card_type,
+      :salary
 
     def initialize(*)
       super

--- a/spec/serialization_spec.rb
+++ b/spec/serialization_spec.rb
@@ -586,44 +586,44 @@ RSpec.describe 'serialization' do
 
       context 'when an extra attribute' do
         before do
-          resource.extra_attribute :first_name, :integer
-          params[:extra_fields] = { employees: 'first_name' }
+          params[:extra_fields] = { employees: 'salary' }
         end
 
         it 'still goes through type coercion' do
-          PORO::Employee.create(first_name: '40')
+          resource.extra_attribute :salary, :integer
+          PORO::Employee.create(salary: '40')
           render
-          expect(attributes['first_name']).to eq(40)
+          expect(attributes['salary']).to eq(40)
         end
 
         context 'with a custom block' do
           before do
-            resource.extra_attribute :first_name, :integer do
+            resource.extra_attribute :salary, :integer do
               '100'
             end
           end
 
           it 'still goes through type coercion' do
-            PORO::Employee.create(first_name: '40')
+            PORO::Employee.create(salary: '40')
             render
-            expect(attributes['first_name']).to eq(100)
+            expect(attributes['salary']).to eq(100)
           end
         end
 
         context 'with a custom block *via the serializer*' do
           before do
             resource.serializer.class_eval do
-              attribute :first_name do
+              attribute :salary do
                 '200'
               end
             end
-            resource.extra_attribute :first_name, :integer
+            resource.extra_attribute :salary, :integer
           end
 
           it 'still goes through coercion' do
-            PORO::Employee.create(first_name: '40')
+            PORO::Employee.create(salary: '40')
             render
-            expect(attributes['first_name']).to eq(200)
+            expect(attributes['salary']).to eq(200)
           end
         end
       end


### PR DESCRIPTION
There's a bunch of logic around serializer attributes: subclassing
resources, explicit serializers, defaults, overrides, etc. So we're
pretty dumb about saying "any time we're doing something that can affect
serialization, re-configure everything".

However, this caused the same attribute to be "wrapped" many times.
"Wrapping" is the process of taking an existing proc on the serializer
and applying type checking/coercion to it. It's needed when there is an
explicit serializer file/class.

Because we would re-fire the logic, we ended up wrapping and rewrapping
procs for no reason. This causes a performance penalty, particularly
with type-coercion firing over and over.

Instead, this commit keeps track of all attributes applied to the
serializer *from the Resource*. This way all the "re-configure
everything" logic can stay the same, but we'll only wrap procs when they
weren't applied by a resource (and thus need to be wrapped with
type-checking).