### PR TITLE
Improve association performance

### DIFF
--- a/lib/graphiti.rb
+++ b/lib/graphiti.rb
@@ -1,6 +1,7 @@
 require 'json'
 require 'forwardable'
 require 'active_support/core_ext/string'
+require 'active_support/core_ext/enumerable'
 require 'active_support/core_ext/class/attribute'
 require 'active_support/core_ext/hash/conversions' # to_xml
 require 'active_support/concern'

--- a/lib/graphiti/sideload.rb
+++ b/lib/graphiti/sideload.rb
@@ -173,13 +173,11 @@ module Graphiti
           associated |= relevant_children
           associate_all(parent, relevant_children)
         else
-          associated << relevant_children
+          associated << relevant_children if relevant_children
           associate(parent, relevant_children)
         end
       end
-      (children - associated).each do |unassigned|
-        children.delete(unassigned)
-      end
+      children.replace(associated)
     end
 
     def resolve(parents, query)

--- a/lib/graphiti/sideload/belongs_to.rb
+++ b/lib/graphiti/sideload/belongs_to.rb
@@ -24,7 +24,8 @@ class Graphiti::Sideload::BelongsTo < Graphiti::Sideload
   end
 
   def assign_each(parent, children)
-    children.find { |c| c.send(primary_key) == parent.send(foreign_key) }
+    children_hash = children.index_by(&primary_key)
+    children_hash[parent.send(foreign_key)]
   end
 
   def ids_for_parents(parents)

--- a/lib/graphiti/sideload/has_many.rb
+++ b/lib/graphiti/sideload/has_many.rb
@@ -15,6 +15,7 @@ class Graphiti::Sideload::HasMany < Graphiti::Sideload
   end
 
   def assign_each(parent, children)
-    children.select { |c| c.send(foreign_key) == parent.send(primary_key) }
+    children_hash = children.group_by(&foreign_key)
+    children_hash[parent.send(primary_key)] || []
   end
 end

--- a/lib/graphiti/sideload/has_one.rb
+++ b/lib/graphiti/sideload/has_one.rb
@@ -4,6 +4,8 @@ class Graphiti::Sideload::HasOne < Graphiti::Sideload::HasMany
   end
 
   def assign_each(parent, children)
-    children.find { |c| c.send(foreign_key) == parent.send(primary_key) }
+    children_hash = children.group_by(&foreign_key)
+    result = children_hash[parent.send(primary_key)] || []
+    result[0]
   end
 end


### PR DESCRIPTION
* Use `index_by` to grab relevant records
* Use `Array#replace` when removing unassigned records

See https://github.com/jsonapi-suite/jsonapi_compliable/pull/135/files