### PR TITLE
Add performant assign internal API

### DIFF
--- a/lib/graphiti/sideload/belongs_to.rb
+++ b/lib/graphiti/sideload/belongs_to.rb
@@ -23,11 +23,6 @@ class Graphiti::Sideload::BelongsTo < Graphiti::Sideload
     { primary_key => parent_ids.join(',') }
   end
 
-  def assign_each(parent, children)
-    children_hash = children.index_by(&primary_key)
-    children_hash[parent.send(foreign_key)]
-  end
-
   def ids_for_parents(parents)
     parent_ids = parents.map(&foreign_key)
     parent_ids.compact!
@@ -44,5 +39,15 @@ class Graphiti::Sideload::BelongsTo < Graphiti::Sideload
       model_name = model.name.gsub("#{namespace}::", '')
       :"#{model_name.underscore}_id"
     end
+  end
+
+  private
+
+  def child_map(children)
+    children.index_by(&primary_key)
+  end
+
+  def children_for(parent, map)
+    map[parent.send(foreign_key)]
   end
 end

--- a/lib/graphiti/sideload/has_many.rb
+++ b/lib/graphiti/sideload/has_many.rb
@@ -14,8 +14,13 @@ class Graphiti::Sideload::HasMany < Graphiti::Sideload
     { foreign_key => ids_for_parents(parents).join(',') }
   end
 
-  def assign_each(parent, children)
-    children_hash = children.group_by(&foreign_key)
-    children_hash[parent.send(primary_key)] || []
+  private
+
+  def child_map(children)
+    children.group_by(&foreign_key)
+  end
+
+  def children_for(parent, map)
+    map[parent.send(primary_key)] || []
   end
 end

--- a/lib/graphiti/sideload/has_one.rb
+++ b/lib/graphiti/sideload/has_one.rb
@@ -3,9 +3,9 @@ class Graphiti::Sideload::HasOne < Graphiti::Sideload::HasMany
     :has_one
   end
 
-  def assign_each(parent, children)
-    children_hash = children.group_by(&foreign_key)
-    result = children_hash[parent.send(primary_key)] || []
-    result[0]
+  private
+
+  def children_for(parent, map)
+    super[0]
   end
 end

--- a/lib/graphiti/sideload/many_to_many.rb
+++ b/lib/graphiti/sideload/many_to_many.rb
@@ -19,6 +19,10 @@ class Graphiti::Sideload::ManyToMany < Graphiti::Sideload::HasMany
     raise 'You must explicitly pass :foreign_key for many-to-many relationships, or override in subclass to return a hash.'
   end
 
+  def performant_assign?
+    false
+  end
+
   def assign_each(parent, children)
     children.select do |c|
       match = ->(ct) { ct.send(true_foreign_key) == parent.send(primary_key) }

--- a/spec/sideload/belongs_to_spec.rb
+++ b/spec/sideload/belongs_to_spec.rb
@@ -23,18 +23,6 @@ RSpec.describe Graphiti::Sideload::BelongsTo do
     end
   end
 
-  describe '#assign_each' do
-    let!(:position) { PORO::Position.new(id: 1, employee_id: 2) }
-    let!(:employee1) { PORO::Position.new(id: 1) }
-    let!(:employee2) { PORO::Position.new(id: 2) }
-    let!(:employees) { [employee1, employee2] }
-
-    it 'selects correct children' do
-      relevant = instance.assign_each(position, employees)
-      expect(relevant).to eq(employee2)
-    end
-  end
-
   describe '#assign' do
     let!(:position1) { PORO::Position.new(id: 1, employee_id: 2) }
     let!(:position2) { PORO::Position.new(id: 2, employee_id: 1) }

--- a/spec/sideload/has_many_spec.rb
+++ b/spec/sideload/has_many_spec.rb
@@ -16,19 +16,6 @@ RSpec.describe Graphiti::Sideload::HasMany do
   let(:name) { :positions }
   let(:instance) { described_class.new(name, opts) }
 
-  describe '#assign_each' do
-    let!(:employee) { PORO::Employee.new(id: 1) }
-    let!(:position1) { PORO::Position.new(id: 1, employee_id: 1) }
-    let!(:position2) { PORO::Position.new(id: 2, employee_id: 2) }
-    let!(:position3) { PORO::Position.new(id: 3, employee_id: 1) }
-    let!(:positions) { [position1, position2, position3] }
-
-    it 'selects correct children' do
-      relevant = instance.assign_each(employee, positions)
-      expect(relevant).to eq([position1, position3])
-    end
-  end
-
   describe '#assign' do
     let!(:employee1) { PORO::Employee.new(id: 1) }
     let!(:employee2) { PORO::Employee.new(id: 2) }

--- a/spec/sideload/has_one_spec.rb
+++ b/spec/sideload/has_one_spec.rb
@@ -6,19 +6,6 @@ RSpec.describe Graphiti::Sideload::HasOne do
   let(:name) { :bio }
   let(:instance) { described_class.new(name, opts) }
 
-  describe '#assign_each' do
-    let!(:employee) { PORO::Employee.new(id: 1) }
-    let!(:bio1) { PORO::Bio.new(id: 1, employee_id: 2) }
-    let!(:bio2) { PORO::Bio.new(id: 2, employee_id: 1) }
-    let!(:bio3) { PORO::Bio.new(id: 3, employee_id: 1) }
-    let!(:bios) { [bio1, bio2, bio3] }
-
-    it 'assigns the first relevant child' do
-      relevant = instance.assign_each(employee, bios)
-      expect(relevant).to eq(bio2)
-    end
-  end
-
   describe '#assign' do
     let!(:employee1) { PORO::Employee.new(id: 1) }
     let!(:employee2) { PORO::Employee.new(id: 2) }


### PR DESCRIPTION
The typical assign_each path works, but is slow. If we can derive the
relevant children without a parent (true for the default case) then we
can improve performance.

This keeps the existing #assign_each dev-facing API, but adds an
internal codepath for a more performant happy path.