### PR TITLE
{WIP} Add `on_rollback` hook to resources

### DIFF
--- a/lib/graphiti/resource/interface.rb
+++ b/lib/graphiti/resource/interface.rb
@@ -21,6 +21,7 @@ module Graphiti
           _find(params, base_scope)
         end
 
+        # @api private
         def _find(params = {}, base_scope = nil)
           id = params[:data].try(:[], :id) || params.delete(:id)
           params[:filter] ||= {}

--- a/spec/fixtures/employee_directory.rb
+++ b/spec/fixtures/employee_directory.rb
@@ -27,6 +27,9 @@ ActiveRecord::Schema.define(:version => 1) do
     t.string :first_name
     t.string :last_name
     t.integer :age
+    t.string :nickname
+    t.string :salutation
+    t.string :professional_titles
   end
 
   create_table :positions do |t|

--- a/spec/rails_spec_helper.rb
+++ b/spec/rails_spec_helper.rb
@@ -51,19 +51,6 @@ end
 class ApplicationController < ActionController::Base
   include Rails.application.routes.url_helpers
   include Graphiti::Rails
-
-  prepend_before_action :fix_params!
-
-  private
-
-  # Honestly not sure why this is needed
-  # Otherwise params is { params: actual_params }
-  def fix_params!
-    if Rails::VERSION::MAJOR == 4
-      good_params = { action: action_name }.merge(params[:params] || {})
-      self.params = ActionController::Parameters.new(good_params.with_indifferent_access)
-    end
-  end
 end
 
 require 'rspec/rails'

--- a/spec/support/rails/employee_controller.rb
+++ b/spec/support/rails/employee_controller.rb
@@ -1,0 +1,37 @@
+EMPLOYEE_CONTROLLER_BLOCK = lambda do |*args|
+  def create
+    employee = EmployeeResource.build(params)
+
+    if employee.save
+      render jsonapi: employee
+    else
+      render json: {
+        errors: {
+          employee: employee.errors,
+          positions: employee.data.positions.map(&:errors),
+          departments: employee.data.positions.map(&:department).compact.map(&:errors)
+        }
+      }
+    end
+  end
+
+  def update
+    employee = EmployeeResource.find(params)
+
+    if employee.update_attributes
+      render jsonapi: employee
+    else
+      render json: { error: employee.errors }
+    end
+  end
+
+  def destroy
+    employee = EmployeeResource.find(params)
+
+    if employee.destroy
+      render json: { meta: {} }
+    else
+      render json: { error: employee.errors }
+    end
+  end
+end


### PR DESCRIPTION
From [@jsonapi-suite/jsonapi_compliable#137](https://github.com/jsonapi-suite/jsonapi_compliable/issues/137), this allows an API
maintainer to run a rollback hook on a given resource if an error occurs
_after_ the resource's `before_commit` hook is successful, but _before_
the transaction actually completes.  This will be helpful in situations
where a user would like to rollback something that cannot be
automatically undone in the transaction. The `on_rollback` hook will
receive as its argument the return value of its `before_callback` hook
(or the created/updated/deleted record if no `before_callback` hook is
provided).

```ruby
class EmployeeResource
  has_many :positions

  before_commit only: :create do |record|
    # Makes HTTP request and returns ID of created record
    PayrollSystem::Employee.create(record)
  end

  on_rollback only: :create do |sap_record_id|
    # Delete created record
    PayrollSystem::Employee.find(sap_record_id).destroy
  end
end

class PositionResource
  before_commit do |record|
    raise 'boom'
  end
end
```

If creating an employee and a nested postion, the position will blow up,
and the rollback hook will clean up after itself.