### PR TITLE
Accomodate Rails-less usage

### DIFF
--- a/graphiti.gemspec
+++ b/graphiti.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'dry-types', '~> 0.13'
   spec.add_dependency 'graphiti_errors', '~> 1.0.alpha.2'
   spec.add_dependency 'concurrent-ruby', '~> 1.0'
+  spec.add_dependency 'activesupport', ['>= 4.1', '< 6']
 
   spec.add_development_dependency "activerecord", ['>= 4.1', '< 6']
   spec.add_development_dependency "kaminari", '~> 0.17'

--- a/lib/graphiti.rb
+++ b/lib/graphiti.rb
@@ -126,6 +126,18 @@ module Graphiti
   def self.resources
     @resources ||= []
   end
+
+  # When we add a sideload, we need to do configuration, such as
+  # adding the relationship to the Resource's serializer.
+  # However, the sideload's Resource class may not be loaded yet.
+  # This is not a problem with Rails autoloading, but is a problem
+  # outside Rails.
+  # In these cases, load every Resource class then call Graphiti.setup!
+  def self.setup!
+    resources.each do |r|
+      r.apply_sideloads_to_serializer
+    end
+  end
 end
 
 require "graphiti/runner"

--- a/lib/graphiti/resource/sideloading.rb
+++ b/lib/graphiti/resource/sideloading.rb
@@ -17,7 +17,7 @@ module Graphiti
             parent.children[name] = sideload
           else
             config[:sideloads][name] = sideload
-            apply_sideloads_to_serializer
+            apply_sideloads_to_serializer if sideload.resource_class_loaded?
           end
           sideload
         end

--- a/lib/graphiti/sideload.rb
+++ b/lib/graphiti/sideload.rb
@@ -261,6 +261,16 @@ module Graphiti
       !self.class.assign_each_proc
     end
 
+    # @api private
+    def resource_class_loaded?
+      begin
+        resource_class
+        true
+      rescue Graphiti::Errors::ResourceNotFound
+        false
+      end
+    end
+
     private
 
     def apply_belongs_to_many_filter

--- a/lib/graphiti/util/serializer_relationships.rb
+++ b/lib/graphiti/util/serializer_relationships.rb
@@ -39,7 +39,9 @@ module Graphiti
 
       def block
         if _link = link?
-          validate_link! unless @sideload.link_proc
+          if @resource_class.validate_endpoints?
+            validate_link! unless @sideload.link_proc
+          end
         end
 
         _sl = @sideload

--- a/spec/graphiti_spec.rb
+++ b/spec/graphiti_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+RSpec.describe Graphiti do
+  describe '.setup!' do
+    let(:resources) do
+      [
+        double(apply_sideloads_to_serializer: nil),
+        double(apply_sideloads_to_serializer: nil)
+      ]
+    end
+
+    before do
+      allow(described_class).to receive(:resources) { resources }
+    end
+
+    it 'iterates through all resources and applies sideloads to serializers' do
+      expect(resources[0]).to receive(:apply_sideloads_to_serializer)
+      expect(resources[1]).to receive(:apply_sideloads_to_serializer)
+      described_class.setup!
+    end
+  end
+end

--- a/spec/integration/rails/activerecord_to_poro_spec.rb
+++ b/spec/integration/rails/activerecord_to_poro_spec.rb
@@ -19,6 +19,8 @@ if ENV['APPRAISAL_INITIALIZED']
         self.model = PORO::State
         attribute :name, :string
       end
+
+      Graphiti.setup!
     end
 
     controller(ApplicationController) do

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -259,16 +259,20 @@ RSpec.describe Graphiti::Resource do
       end
 
       context 'when sideloading' do
+        let(:some_resource) do
+          Class.new(Graphiti::Resource)
+        end
+
         let(:klass1) do
-          Class.new(app_resource) do
-            allow_sideload :foo, type: :has_many
-          end
+          klass = Class.new(app_resource)
+          klass.allow_sideload :foo, type: :has_many, resource: some_resource
+          klass
         end
 
         let(:klass2) do
-          Class.new(klass1) do
-            allow_sideload :bar, type: :belongs_to
-          end
+          klass = Class.new(klass1)
+          klass.allow_sideload :bar, type: :belongs_to, resource: some_resource
+          klass
         end
 
         it 'inherits sideloads from the parent' do

--- a/spec/serialization_spec.rb
+++ b/spec/serialization_spec.rb
@@ -30,8 +30,9 @@ RSpec.describe 'serialization' do
     end
 
     it 'has all readable sideloads of the resource' do
-      resource.allow_sideload :foobles, type: :has_many
-      resource.allow_sideload :barble, type: :belongs_to
+      other = Class.new(Graphiti::Resource)
+      resource.allow_sideload :foobles, type: :has_many, resource: other
+      resource.allow_sideload :barble, type: :belongs_to, resource: other
       expect(resource.serializer.relationship_blocks.keys)
         .to eq([:foobles, :barble])
     end
@@ -975,10 +976,28 @@ RSpec.describe 'serialization' do
             }
           end
 
-          it 'raises error' do
-            expect {
-              resource.has_many :positions
-            }.to raise_error(Graphiti::Errors::InvalidLink, /Make sure the endpoint \"\/poro\/positions\" exists with action :index/)
+          context 'when validating endpoints' do
+            before do
+              resource.validate_endpoints = true
+            end
+
+            it 'raises error' do
+              expect {
+                resource.has_many :positions
+              }.to raise_error(Graphiti::Errors::InvalidLink, /Make sure the endpoint \"\/poro\/positions\" exists with action :index/)
+            end
+          end
+
+          context 'when not validating endpoints' do
+            before do
+              resource.validate_endpoints = false
+            end
+
+            it 'does not raise error' do
+              expect {
+                resource.has_many :positions
+              }.to_not raise_error
+            end
           end
         end
 
@@ -987,10 +1006,28 @@ RSpec.describe 'serialization' do
             Graphiti.config.context_for_endpoint = nil
           end
 
-          it 'raises error' do
-            expect {
-              resource.has_many :positions
-            }.to raise_error(Graphiti::Errors::Unlinkable, /Graphiti.config.context_for_endpoint/)
+          context 'when validating endpoints' do
+            before do
+              resource.validate_endpoints = true
+            end
+
+            it 'raises error' do
+              expect {
+                resource.has_many :positions
+              }.to raise_error(Graphiti::Errors::Unlinkable, /Graphiti.config.context_for_endpoint/)
+            end
+          end
+
+          context 'when not validating endpoints' do
+            before do
+              resource.validate_endpoints = false
+            end
+
+            it 'does not raise error' do
+              expect {
+                resource.has_many :positions
+              }.to_not raise_error
+            end
           end
         end
       end
@@ -1116,10 +1153,28 @@ RSpec.describe 'serialization' do
             }
           end
 
-          it 'raises error' do
-            expect {
-              resource.belongs_to :classification
-            }.to raise_error(Graphiti::Errors::InvalidLink, /Make sure the endpoint \"\/poro\/classifications\" exists with action :show/)
+          context 'when validating endpoints' do
+            before do
+              resource.validate_endpoints = true
+            end
+
+            it 'raises error' do
+              expect {
+                resource.belongs_to :classification
+              }.to raise_error(Graphiti::Errors::InvalidLink, /Make sure the endpoint \"\/poro\/classifications\" exists with action :show/)
+            end
+          end
+
+          context 'when not validating endpoints' do
+            before do
+              resource.validate_endpoints = false
+            end
+
+            it 'does not raise error' do
+              expect {
+                resource.belongs_to :classification
+              }.to_not raise_error
+            end
           end
         end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ require 'graphiti'
 # Avoiding loading classes before we're ready
 Graphiti::Resource.autolink = false
 require 'fixtures/poro'
+Graphiti.setup!
 
 RSpec.configure do |config|
   config.include GraphitiSpecHelpers::RSpec


### PR DESCRIPTION
* Only validate links when validate_endpoints is true
* Defer serializer relationship logic when not able to take advantage of
Rails autoloading. Define classes first then call `Graphiti.setup!`
* Add activesupport dependency