### PR TITLE
WIP - Spike integration of Opentracing standard

### DIFF
--- a/graphiti.gemspec
+++ b/graphiti.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'graphiti_errors', '~> 1.0.beta.1'
   spec.add_dependency 'concurrent-ruby', '~> 1.0'
   spec.add_dependency 'activesupport', ['>= 4.1', '< 6']
+  spec.add_dependency 'opentracing', '~> 0.4.3'
 
   spec.add_development_dependency "activerecord", ['>= 4.1', '< 6']
   spec.add_development_dependency "kaminari", '~> 0.17'

--- a/lib/graphiti.rb
+++ b/lib/graphiti.rb
@@ -69,6 +69,7 @@ require "graphiti/extensions/boolean_attribute"
 require "graphiti/extensions/temp_id"
 require "graphiti/serializer"
 require "graphiti/debugger"
+require "graphiti/tracing"
 
 if defined?(ActiveRecord)
   require 'graphiti/adapters/active_record'
@@ -154,6 +155,14 @@ module Graphiti
   def self.log(msg, color = :white, bold = false)
     colored = ActiveSupport::LogSubscriber.new.send(:color, msg, color, bold)
     logger.debug(colored)
+  end
+
+  def self.tracer
+    @tracer ||= Graphiti::Tracer.new
+  end
+
+  def self.tracer=(tracer)
+    @tracer = tracer
   end
 
   # When we add a sideload, we need to do configuration, such as

--- a/lib/graphiti/base.rb
+++ b/lib/graphiti/base.rb
@@ -43,6 +43,7 @@ module Graphiti
           Graphiti::Deserializer.new(payload)
         end
       end
+
     end
 
     def jsonapi_render_options

--- a/lib/graphiti/debugger.rb
+++ b/lib/graphiti/debugger.rb
@@ -9,22 +9,22 @@ module Graphiti
     self.chunks = []
 
     class << self
-      def on_data(name, start, stop, id, payload)
+      def on_resolve(name, start, stop, id, payload)
         took = ((stop-start)*1000.0).round(2)
         params = scrub_params(payload[:params])
 
         if payload[:exception]
-          on_data_exception(payload, params)
+          on_resolve_exception(payload, params)
         else
           if payload[:sideload]
-            on_sideload_data(payload, params, took)
+            on_sideload_resolve(payload, params, took)
           else
-            on_primary_data(payload, params, took)
+            on_primary_resolve(payload, params, took)
           end
         end
       end
 
-      def on_data_exception(payload, params)
+      def on_resolve_exception(payload, params)
         unless payload[:exception_object].instance_variable_get(:@__graphiti_debug)
           add_chunk do |logs, json|
             logs << ["\n=== Graphiti Debug ERROR", :red, true]
@@ -55,7 +55,7 @@ module Graphiti
         raw_results.map { |r| "[#{r.class.name}, #{r.id.inspect}]" }.join(', ')
       end
 
-      def on_sideload_data(payload, params, took)
+      def on_sideload_resolve(payload, params, took)
         sideload = payload[:sideload]
         results = results(payload[:results])
         add_chunk(payload[:resource], payload[:parent]) do |logs, json|
@@ -73,7 +73,7 @@ module Graphiti
         end
       end
 
-      def on_primary_data(payload, params, took)
+      def on_primary_resolve(payload, params, took)
         results = results(payload[:results])
         add_chunk(payload[:resource], payload[:parent]) do |logs, json|
           logs << [""]
@@ -189,7 +189,7 @@ module Graphiti
     end
 
     ActiveSupport::Notifications.subscribe \
-      'graphiti.data', method(:on_data)
+      'graphiti.resolve', method(:on_resolve)
     ActiveSupport::Notifications.subscribe \
       'graphiti.render', method(:on_render)
   end

--- a/lib/graphiti/railtie.rb
+++ b/lib/graphiti/railtie.rb
@@ -30,6 +30,12 @@ module Graphiti
       configure_endpoint_lookup
     end
 
+    initializer 'graphti.logger' do
+      config.after_initialize do
+        Graphiti.logger = ::Rails.logger
+      end
+    end
+
     # from jsonapi-rails
     PARSER = lambda do |body|
       data = JSON.parse(body)

--- a/lib/graphiti/renderer.rb
+++ b/lib/graphiti/renderer.rb
@@ -38,7 +38,7 @@ module Graphiti
     private
 
     def render(renderer)
-      Graphiti.broadcast(:render, records: records, options: options) do
+      Graphiti.tracer.trace('render', records: records, options: options) do
         options[:fields] = proxy.fields
         options[:expose] ||= {}
         options[:expose][:extra_fields] = proxy.extra_fields

--- a/lib/graphiti/sideload.rb
+++ b/lib/graphiti/sideload.rb
@@ -199,7 +199,7 @@ module Graphiti
       end
 
       if self.class.scope_proc
-        Graphiti.broadcast("data", resource_class: resource.class, sideload: self) do |payload|
+        Graphiti.broadcast("resolve", resource_class: resource.class, sideload: self) do |payload|
           sideload_scope = fire_scope(parents)
           sideload_scope = Scope.new sideload_scope,
             resource,

--- a/lib/graphiti/tracing.rb
+++ b/lib/graphiti/tracing.rb
@@ -1,0 +1,55 @@
+require 'opentracing'
+
+module Graphiti
+  class Tracer
+    def start_active_span(operation_name, *args)
+      operation_name = "graphiti.#{operation_name}"
+
+      if block_given?
+        tracing.start_active_span(operation_name, *args) do |scope|
+          apply_tags(scope.span, standard_tags)
+
+          yield scope
+        end
+      else
+        tracing.start_active_span(operation_name, *args).tap do |scope|
+          apply_tags(scope.span, standard_tags)
+        end
+      end
+    end
+
+    def trace(operation_name)
+      ret_val = nil
+
+      start_active_span(operation_name) do |scope|
+        ret_val = yield scope
+      end
+
+      ret_val
+    end
+
+    def set_scope_tags(span, query_hash)
+      tags = {
+        'graphiti.filters' => query_hash[:filter],
+        'graphiti.pagination' => query_hash[:page],
+        'graphiti.sorting' => query_hash[:sort],
+      }.compact.as_json
+      apply_tags(span, tags)
+    end
+
+    private
+    def tracing
+      OpenTracing
+    end
+
+    def apply_tags(span, tags)
+      tags.each_pair do |k,v|
+        span.set_tag(k,v)
+      end
+    end
+
+    def standard_tags
+      {}
+    end
+  end
+end

--- a/lib/graphiti/tracing.rb
+++ b/lib/graphiti/tracing.rb
@@ -18,34 +18,27 @@ module Graphiti
       end
     end
 
-    def trace(operation_name)
+    def trace(operation_name, context = nil)
       ret_val = nil
 
       start_active_span(operation_name) do |scope|
-        ret_val = yield scope
+        Graphiti.broadcast(operation_name, context) do
+          ret_val = yield scope
+        end
       end
 
       ret_val
     end
 
-    def set_scope_tags(span, query_hash)
-      tags = {
-        'graphiti.filters' => query_hash[:filter],
-        'graphiti.pagination' => query_hash[:page],
-        'graphiti.sorting' => query_hash[:sort],
-      }.compact.as_json
-      apply_tags(span, tags)
+    def apply_tags(span, tags)
+      tags.compact.as_json.each_pair do |k,v|
+        span.set_tag(k,v)
+      end
     end
 
     private
     def tracing
       OpenTracing
-    end
-
-    def apply_tags(span, tags)
-      tags.each_pair do |k,v|
-        span.set_tag(k,v)
-      end
     end
 
     def standard_tags


### PR DESCRIPTION
This is a _very_ rough pass at implementing the `opentracing` gem, which
is created to follow the [Opentracing Standard](https://opentracing.io/). Tools integrating with opentracing
are supported out of the box by a number of APM tools available in the
industry, and connecting support for others becomes much easier through
the standard interface provided.  This will allow more granular
performance optimization than the log debugger we have in place now.

As I said above, this is still pretty rough and doesn't have specs or
anything, but I wanted to get something out for discussion purposes. I'd
ideally like to use ActiveSupport::Notifications the same way we are
already doign for the debug log, but as far as I know it only supports
point-in-time notifications, as opposed to wrapping the entire timeframe
for a call, which is important for tracing.

Right now the debugger and the tracer are both using slightly different
event names as well (and the things they are tracking don't 100%
overlap yet). Ideally both of these could be resolved before this makes
it into master.