### PR TITLE
[POC] Allow Graphiti usage for api requests to be optional

### DIFF
--- a/lib/graphiti/jsonapi_serializable_ext.rb
+++ b/lib/graphiti/jsonapi_serializable_ext.rb
@@ -7,6 +7,7 @@ module Graphiti
     # To ensure we always render with the *resource* serializer
     module RendererOverrides
       def _build(object, exposures, klass)
+        puts "class name is #{klass}"
         resource = object.instance_variable_get(:@__graphiti_resource)
         klass = object.instance_variable_get(:@__graphiti_serializer)
         klass.new(exposures.merge(object: object, resource: resource))

--- a/lib/graphiti/jsonapi_serializable_ext.rb
+++ b/lib/graphiti/jsonapi_serializable_ext.rb
@@ -24,6 +24,8 @@ module Graphiti
       def data
         @_resources_block = proc do
           resources = yield
+          puts "RESOURCES: #{resources.inspect}"
+
           if resources.nil?
             nil
           elsif resources.respond_to?(:to_ary)
@@ -41,7 +43,7 @@ module Graphiti
       end
     end
 
-    JSONAPI::Serializable::Relationship.send(:include, RelationshipOverrides)
+    JSONAPI::Serializable::Relationship.send(:prepend, RelationshipOverrides)
     JSONAPI::Serializable::Renderer.send(:prepend, RendererOverrides)
   end
 end

--- a/lib/graphiti/jsonapi_serializable_ext.rb
+++ b/lib/graphiti/jsonapi_serializable_ext.rb
@@ -42,6 +42,6 @@ module Graphiti
     end
 
     JSONAPI::Serializable::Relationship.send(:include, RelationshipOverrides)
-    JSONAPI::Serializable::Renderer.send(:include, RendererOverrides)
+    JSONAPI::Serializable::Renderer.send(:prepend, RendererOverrides)
   end
 end

--- a/lib/graphiti/jsonapi_serializable_ext.rb
+++ b/lib/graphiti/jsonapi_serializable_ext.rb
@@ -9,8 +9,13 @@ module Graphiti
       def _build(object, exposures, klass)
         puts exposures
         resource = object.instance_variable_get(:@__graphiti_resource)
-        klass = object.instance_variable_get(:@__graphiti_serializer)
-        klass.new(exposures.merge(object: object, resource: resource))
+
+        if resource.present?
+          klass = object.instance_variable_get(:@__graphiti_serializer)
+          klass.new(exposures.merge(object: object, resource: resource))
+        else
+          super(object, exposures, klass)
+        end
       end
     end
 
@@ -36,7 +41,7 @@ module Graphiti
       end
     end
 
-    JSONAPI::Serializable::Relationship.send(:prepend, RelationshipOverrides)
-    JSONAPI::Serializable::Renderer.send(:prepend, RendererOverrides)
+    JSONAPI::Serializable::Relationship.send(:include, RelationshipOverrides)
+    JSONAPI::Serializable::Renderer.send(:include, RendererOverrides)
   end
 end

--- a/lib/graphiti/jsonapi_serializable_ext.rb
+++ b/lib/graphiti/jsonapi_serializable_ext.rb
@@ -24,7 +24,7 @@ module Graphiti
       def data
         @_resources_block = proc do
           resources = yield
-          puts "RESOURCES: #{resources.inspect}"
+          binding.pry
 
           if resources.nil?
             nil

--- a/lib/graphiti/jsonapi_serializable_ext.rb
+++ b/lib/graphiti/jsonapi_serializable_ext.rb
@@ -6,11 +6,7 @@ module Graphiti
     # Instead, this variable is assigned when the query is resolved
     # To ensure we always render with the *resource* serializer
     module RendererOverrides
-      def _build(object, exposures, klass)
-        puts "class name is #{klass}"
-        puts exposures.inspect
-        puts "controller is #{self.class.name}"
-        
+      def _build(object, exposures, klass)        
         if klass.values.any?
           klass[object.class.name.to_sym].new(exposures.merge(object: object))
         else    

--- a/lib/graphiti/jsonapi_serializable_ext.rb
+++ b/lib/graphiti/jsonapi_serializable_ext.rb
@@ -8,6 +8,7 @@ module Graphiti
     module RendererOverrides
       def _build(object, exposures, klass)
         puts "class name is #{klass}"
+        puts exposures.inspect
         resource = object.instance_variable_get(:@__graphiti_resource)
         klass = object.instance_variable_get(:@__graphiti_serializer)
         klass.new(exposures.merge(object: object, resource: resource))

--- a/lib/graphiti/jsonapi_serializable_ext.rb
+++ b/lib/graphiti/jsonapi_serializable_ext.rb
@@ -36,7 +36,7 @@ module Graphiti
       end
     end
 
-    JSONAPI::Serializable::Relationship.send(:include, RelationshipOverrides)
-    JSONAPI::Serializable::Renderer.send(:include, RendererOverrides)
+    JSONAPI::Serializable::Relationship.send(:prepend, RelationshipOverrides)
+    JSONAPI::Serializable::Renderer.send(:prepend, RendererOverrides)
   end
 end

--- a/lib/graphiti/jsonapi_serializable_ext.rb
+++ b/lib/graphiti/jsonapi_serializable_ext.rb
@@ -9,7 +9,7 @@ module Graphiti
       def _build(object, exposures, klass)
         puts "class name is #{klass}"
         puts exposures.inspect
-        puts "controller is #{self}"
+        puts "controller is #{self.class.name}"
         resource = object.instance_variable_get(:@__graphiti_resource)
         klass = object.instance_variable_get(:@__graphiti_serializer)
         klass.new(exposures.merge(object: object, resource: resource))

--- a/lib/graphiti/jsonapi_serializable_ext.rb
+++ b/lib/graphiti/jsonapi_serializable_ext.rb
@@ -6,10 +6,12 @@ module Graphiti
     # Instead, this variable is assigned when the query is resolved
     # To ensure we always render with the *resource* serializer
     module RendererOverrides
-      def _build(object, exposures, klass)        
+      def _build(object, exposures, klass)
+        puts exposures
+
         if klass.values.any?
           klass[object.class.name.to_sym].new(exposures.merge(object: object))
-        else    
+        else
           resource = object.instance_variable_get(:@__graphiti_resource)
           klass = object.instance_variable_get(:@__graphiti_serializer)
           klass.new(exposures.merge(object: object, resource: resource))
@@ -39,7 +41,7 @@ module Graphiti
       end
     end
 
-    JSONAPI::Serializable::Relationship.send(:prepend, RelationshipOverrides)
-    JSONAPI::Serializable::Renderer.send(:prepend, RendererOverrides)
+    JSONAPI::Serializable::Relationship.send(:include, RelationshipOverrides)
+    JSONAPI::Serializable::Renderer.send(:include, RendererOverrides)
   end
 end

--- a/lib/graphiti/jsonapi_serializable_ext.rb
+++ b/lib/graphiti/jsonapi_serializable_ext.rb
@@ -10,9 +10,14 @@ module Graphiti
         puts "class name is #{klass}"
         puts exposures.inspect
         puts "controller is #{self.class.name}"
-        resource = object.instance_variable_get(:@__graphiti_resource)
-        klass = object.instance_variable_get(:@__graphiti_serializer)
-        klass.new(exposures.merge(object: object, resource: resource))
+        
+        if klass.values.any?
+          klass[object.class.name.to_sym].new(exposures.merge(object: object))
+        else    
+          resource = object.instance_variable_get(:@__graphiti_resource)
+          klass = object.instance_variable_get(:@__graphiti_serializer)
+          klass.new(exposures.merge(object: object, resource: resource))
+        end
       end
     end
 

--- a/lib/graphiti/jsonapi_serializable_ext.rb
+++ b/lib/graphiti/jsonapi_serializable_ext.rb
@@ -8,14 +8,9 @@ module Graphiti
     module RendererOverrides
       def _build(object, exposures, klass)
         puts exposures
-
-        if klass.values.any?
-          klass[object.class.name.to_sym].new(exposures.merge(object: object))
-        else
-          resource = object.instance_variable_get(:@__graphiti_resource)
-          klass = object.instance_variable_get(:@__graphiti_serializer)
-          klass.new(exposures.merge(object: object, resource: resource))
-        end
+        resource = object.instance_variable_get(:@__graphiti_resource)
+        klass = object.instance_variable_get(:@__graphiti_serializer)
+        klass.new(exposures.merge(object: object, resource: resource))
       end
     end
 

--- a/lib/graphiti/jsonapi_serializable_ext.rb
+++ b/lib/graphiti/jsonapi_serializable_ext.rb
@@ -35,9 +35,7 @@ module Graphiti
       end
     end
 
-    JSONAPI::Serializable::Relationship
-      .send(:prepend, RelationshipOverrides)
-    JSONAPI::Serializable::Renderer
-      .send(:prepend, RendererOverrides)
+#     JSONAPI::Serializable::Relationship.send(:prepend, RelationshipOverrides)
+#     JSONAPI::Serializable::Renderer.send(:prepend, RendererOverrides)
   end
 end

--- a/lib/graphiti/jsonapi_serializable_ext.rb
+++ b/lib/graphiti/jsonapi_serializable_ext.rb
@@ -36,7 +36,7 @@ module Graphiti
       end
     end
 
-#     JSONAPI::Serializable::Relationship.send(:prepend, RelationshipOverrides)
-#     JSONAPI::Serializable::Renderer.send(:prepend, RendererOverrides)
+    JSONAPI::Serializable::Relationship.send(:prepend, RelationshipOverrides)
+    JSONAPI::Serializable::Renderer.send(:prepend, RendererOverrides)
   end
 end

--- a/lib/graphiti/jsonapi_serializable_ext.rb
+++ b/lib/graphiti/jsonapi_serializable_ext.rb
@@ -9,6 +9,7 @@ module Graphiti
       def _build(object, exposures, klass)
         puts "class name is #{klass}"
         puts exposures.inspect
+        puts "controller is #{self}"
         resource = object.instance_variable_get(:@__graphiti_resource)
         klass = object.instance_variable_get(:@__graphiti_serializer)
         klass.new(exposures.merge(object: object, resource: resource))

--- a/lib/graphiti/jsonapi_serializable_ext.rb
+++ b/lib/graphiti/jsonapi_serializable_ext.rb
@@ -1,7 +1,3 @@
-# This patch is necessary in order to support V1 of the API using JSONAPI-RAILS
-# while supporting V2 using Graphiti.
-# TODO: Remove this class when we no longer support V1 of the API
-
 module Graphiti
   module JsonapiSerializableExt
     # This library looks up a serializer based on the record's class name

--- a/lib/graphiti/railtie.rb
+++ b/lib/graphiti/railtie.rb
@@ -22,7 +22,7 @@ module Graphiti
       end
 
       if Mime[:jsonapi].nil? # rails 4
-        Mime::Type.register('application/vnd.api+json', :jsonapi)
+        Mime::Type.register('application/vnd.api+json', :graphiti)
       end
       register_parameter_parser
       register_renderers

--- a/lib/graphiti/railtie.rb
+++ b/lib/graphiti/railtie.rb
@@ -21,7 +21,7 @@ module Graphiti
         end
       end
 
-      if Mime[:jsonapi].nil? # rails 4
+      if Mime[:graphiti].nil? # rails 4
         Mime::Type.register('application/vnd.api+json', :graphiti)
       end
       register_parameter_parser
@@ -64,7 +64,7 @@ module Graphiti
       end
 
       ActiveSupport.on_load(:action_controller) do
-        ::ActionController::Renderers.add(:jsonapi_errors) do |proxy, options|
+        ::ActionController::Renderers.add(:graphiti_errors) do |proxy, options|
           self.content_type ||= Mime[:graphiti]
 
           validation = GraphitiErrors::Serializers::Validation.new \

--- a/lib/graphiti/railtie.rb
+++ b/lib/graphiti/railtie.rb
@@ -33,22 +33,22 @@ module Graphiti
     # from jsonapi-rails
     PARSER = lambda do |body|
       data = JSON.parse(body)
-      data[:format] = :jsonapi
+      data[:format] = :graphiti
       data.with_indifferent_access
     end
 
     def register_parameter_parser
       if ::Rails::VERSION::MAJOR >= 5
-        ActionDispatch::Request.parameter_parsers[:jsonapi] = PARSER
+        ActionDispatch::Request.parameter_parsers[:graphiti] = PARSER
       else
-        ActionDispatch::ParamsParser::DEFAULT_PARSERS[Mime[:jsonapi]] = PARSER
+        ActionDispatch::ParamsParser::DEFAULT_PARSERS[Mime[:graphiti]] = PARSER
       end
     end
 
     def register_renderers
       ActiveSupport.on_load(:action_controller) do
         ::ActionController::Renderers.add(:graphiti) do |proxy, options|
-          self.content_type ||= Mime[:jsonapi]
+          self.content_type ||= Mime[:graphiti]
 
           opts = {}
           if respond_to?(:default_jsonapi_render_options)
@@ -65,7 +65,7 @@ module Graphiti
 
       ActiveSupport.on_load(:action_controller) do
         ::ActionController::Renderers.add(:jsonapi_errors) do |proxy, options|
-          self.content_type ||= Mime[:jsonapi]
+          self.content_type ||= Mime[:graphiti]
 
           validation = GraphitiErrors::Serializers::Validation.new \
             proxy.data, proxy.payload.relationships

--- a/lib/graphiti/railtie.rb
+++ b/lib/graphiti/railtie.rb
@@ -47,7 +47,7 @@ module Graphiti
 
     def register_renderers
       ActiveSupport.on_load(:action_controller) do
-        ::ActionController::Renderers.add(:jsonapi) do |proxy, options|
+        ::ActionController::Renderers.add(:graphiti) do |proxy, options|
           self.content_type ||= Mime[:jsonapi]
 
           opts = {}


### PR DESCRIPTION
## Goal
At the moment this library does not play nice when using an API already built on JSONAPI Rails. This is because it includes this gem and overrides some default behavior. It would be AMAZING if this library could run along side the jsonapi-rails gem!

### How (options & ideas)
* Look for an instance variable defined in the controller and render conditionally (something like `@graphiti_controller == true`
* Introduce libary configuration that is used at render time. (Something like `Graphiti.config.strict`) which would only manipulate requests/params/etc if the current route was in Graphiti's api_namespace.
* Alter Graphiti so that it only manipulates requests under it's defined namespace.

### Approach
I opted for altering the library code to make its inclusion in projects a little easier. The idea here is that if someone is creating an API or a new version and are already using some of the dependent gems in this project...there is no conflict (other than gem version potentially).

### Problems With Approach
* Graphiti currently only supports a singular api_namespace. So if someone was building an API under `/v1` and then added another API version under `/v2` which also used Graphiti...then the second version would run into a problem.