### PR TITLE
Redefine total count when switching adapter

### DIFF
--- a/lib/graphiti/resource/configuration.rb
+++ b/lib/graphiti/resource/configuration.rb
@@ -28,6 +28,13 @@ module Graphiti
           end
         end
 
+        # The .stat call stores a proc based on adapter
+        # So if we assign a new adapter, reconfigure
+        def adapter=(val)
+          super
+          stat total: [:count]
+        end
+
         def model
           klass = super
           unless klass || abstract_class?

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -67,6 +67,26 @@ RSpec.describe Graphiti::Resource do
         expect(klass.relationships_writable_by_default).to eq(true)
       end
 
+      context 'when assigning new adapter' do
+        let(:adapter) do
+          Class.new(Graphiti::Adapters::Abstract) do
+            def count(*args)
+              42
+            end
+          end
+        end
+
+        def count
+          klass.config[:stats][:total].calculations[:count].call
+        end
+
+        it 'updates total count config' do
+          expect { count }.to raise_error(ArgumentError)
+          klass.adapter = adapter
+          expect(count).to eq(42)
+        end
+      end
+
       context 'when model can be inferred' do
         before do
           klass.class_eval do


### PR DESCRIPTION
Total count is defined for all Resources by default. But if a resource
subclasses another and changes adapter, the total count will not use the
correct adapter because it was set before the adapter.

We should probably lazily grab the stat at runtime for this reason, but
this is the simple bugfix.