### PR TITLE
Serialize DateTime objects with #to_datetime if possible

### DIFF
--- a/lib/graphiti/types.rb
+++ b/lib/graphiti/types.rb
@@ -7,7 +7,11 @@ module Graphiti
 
     WriteDateTime = create(::DateTime) do |input|
       if input.is_a?(::Date) || input.is_a?(::Time)
-        input = ::DateTime.parse(input.to_s)
+        input = if input.respond_to?(:to_datetime)
+                  input.to_datetime
+                else
+                  ::DateTime.parse(input.to_s)
+                end
       end
       input = Dry::Types['json.date_time'][input]
       Dry::Types['strict.date_time'][input] if input
@@ -15,7 +19,11 @@ module Graphiti
 
     ReadDateTime = create(::DateTime) do |input|
       if input.is_a?(::Date) || input.is_a?(::Time)
-        input = ::DateTime.parse(input.to_s)
+        input = if input.respond_to?(:to_datetime)
+                  input.to_datetime
+                else
+                  ::DateTime.parse(input.to_s)
+                end
       end
       input = Dry::Types['json.date_time'][input]
       Dry::Types['strict.date_time'][input].iso8601 if input


### PR DESCRIPTION
Attempt to keep as much precision as possible when serializing
datetime types. Calling #to_s on Time and other (time) objects loses
precision down to the second.