### PR TITLE
Query with persistence

### DIFF
--- a/lib/graphiti/resource/interface.rb
+++ b/lib/graphiti/resource/interface.rb
@@ -21,6 +21,7 @@ module Graphiti
           _find(params, base_scope)
         end
 
+        # @api private
         def _find(params = {}, base_scope = nil)
           id = params[:data].try(:[], :id) || params.delete(:id)
           params[:filter] ||= {}

--- a/lib/graphiti/resource_proxy.rb
+++ b/lib/graphiti/resource_proxy.rb
@@ -93,7 +93,12 @@ module Graphiti
       @data, success = validator.to_a
 
       if success
-        @scope.resolve_sideloads([@data])
+        # If the context namespace is `update` or `create`, certain
+        # adapters will cause N+1 validation calls, so lets explicitly
+        # switch to a lookup context.
+        Graphiti.with_context(Graphiti.context[:object], :show) do
+          @scope.resolve_sideloads([@data])
+        end
       end
 
       success

--- a/lib/graphiti/resource_proxy.rb
+++ b/lib/graphiti/resource_proxy.rb
@@ -91,6 +91,11 @@ module Graphiti
           @payload.relationships
       end
       @data, success = validator.to_a
+
+      if success
+        @scope.resolve_sideloads([@data])
+      end
+
       success
     end
 
@@ -113,7 +118,10 @@ module Graphiti
     end
 
     def include_hash
-      @payload ? @payload.include_hash : @query.include_hash
+      @include_hash ||= begin
+        base = @payload ? @payload.include_hash : {}
+        base.deep_merge(@query.include_hash)
+      end
     end
 
     def fields

--- a/spec/fixtures/employee_directory.rb
+++ b/spec/fixtures/employee_directory.rb
@@ -126,6 +126,7 @@ class Department < ApplicationRecord
 end
 
 class Salary < ApplicationRecord
+  belongs_to :employee
 end
 
 class ApplicationResource < Graphiti::Resource

--- a/spec/fixtures/employee_directory.rb
+++ b/spec/fixtures/employee_directory.rb
@@ -27,6 +27,9 @@ ActiveRecord::Schema.define(:version => 1) do
     t.string :first_name
     t.string :last_name
     t.integer :age
+    t.string :nickname
+    t.string :salutation
+    t.string :professional_titles
   end
 
   create_table :positions do |t|
@@ -111,10 +114,6 @@ class Employee < ApplicationRecord
       errors.blank?
     end
   end
-
-  def nickname
-    %w[Champ Sport Slugger].sample
-  end
 end
 
 class Position < ApplicationRecord
@@ -146,7 +145,7 @@ class DepartmentResource < ApplicationResource
 end
 
 class PositionResource < ApplicationResource
-  attribute :employee_id, :integer, only: [:writable]
+  attribute :employee_id, :integer, only: [:writable, :filterable]
   attribute :title, :string
   belongs_to :department
 end
@@ -164,7 +163,7 @@ end
 class SalaryResource < ApplicationResource
   self.description = "An employee salary"
 
-  attribute :employee_id, :integer, only: [:writable]
+  attribute :employee_id, :integer, only: [:writable, :filterable]
   attribute :base_rate, :float
   attribute :overtime_rate, :float
 end

--- a/spec/integration/rails/activerecord_to_poro_spec.rb
+++ b/spec/integration/rails/activerecord_to_poro_spec.rb
@@ -45,7 +45,7 @@ if ENV['APPRAISAL_INITIALIZED']
 
     context 'when has_many' do
       it 'works' do
-        get :index, params: { include: 'books' }
+        do_index({ include: 'books' })
         sl = d[0].sideload(:books)
         expect(sl.map(&:id)).to eq([book.id])
         expect(sl[0].jsonapi_type).to eq('books')
@@ -54,7 +54,7 @@ if ENV['APPRAISAL_INITIALIZED']
 
     context 'when belongs_to' do
       it 'works' do
-        get :index, params: { include: 'state' }
+        do_index({ include: 'state' })
         sl = d[0].sideload(:state)
         expect(sl.id).to eq(state.id)
         expect(sl.jsonapi_type).to eq('states')

--- a/spec/integration/rails/finders_spec.rb
+++ b/spec/integration/rails/finders_spec.rb
@@ -64,34 +64,34 @@ if ENV['APPRAISAL_INITIALIZED']
     let(:path) { '/legacy/authors' }
 
     it 'allows basic sorting' do
-      get :index, params: { sort: '-id' }
+      do_index({ sort: '-id' })
       expect(d.map(&:id)).to eq([author2.id, author1.id])
     end
 
     it 'allows basic pagination' do
-      get :index, params: { page: { number: 2, size: 1 } }
+      do_index({ page: { number: 2, size: 1 } })
       expect(d.map(&:id)).to eq([author2.id])
     end
 
     it 'allows allowlisted filters (and other configs)' do
-      get :index, params: { filter: { first_name: 'George' } }
+      do_index({ filter: { first_name: 'George' } })
       expect(d.map(&:id)).to eq([author2.id])
     end
 
     it 'allows basic sideloading' do
-      get :index, params: { include: 'books' }
+      do_index({ include: 'books' })
       expect(included.map(&:jsonapi_type).uniq).to match_array(%w(books))
     end
 
     it 'allows nested sideloading' do
-      get :index, params: { include: 'books.genre' }
+      do_index({ include: 'books.genre' })
       expect(included.map(&:jsonapi_type).uniq)
         .to match_array(%w(books genres))
     end
 
     describe 'filtering' do
       subject(:ids) do
-        get :index, params: { filter: filter }
+        do_index({ filter: filter })
         d.map(&:id)
       end
 
@@ -129,24 +129,24 @@ if ENV['APPRAISAL_INITIALIZED']
       context 'when a uuid' do
         context 'eq' do
           it 'executes case-sensitive search (invalid)' do
-            get :index, params: { filter: { identifier: 'abc123' } }
+            do_index({ filter: { identifier: 'abc123' } })
             expect(d.map(&:id)).to eq([])
           end
 
           it 'executes case-sensitive search (valid)' do
-            get :index, params: { filter: { identifier: 'AbC123' } }
+            do_index({ filter: { identifier: 'AbC123' } })
             expect(d.map(&:id)).to eq([author3.id])
           end
         end
 
         context '!eq' do
           it 'executes case-sensitive search (invalid)' do
-            get :index, params: { filter: { identifier: { not_eq: 'abc123' } } }
+            do_index({ filter: { identifier: { not_eq: 'abc123' } } })
             expect(d.map(&:id).length).to eq(3)
           end
 
           it 'executes case-sensitive search (valid)' do
-            get :index, params: { filter: { identifier: { not_eq: 'AbC123' } } }
+            do_index({ filter: { identifier: { not_eq: 'AbC123' } } })
             expect(d.map(&:id).length).to eq(2)
           end
         end
@@ -620,13 +620,7 @@ if ENV['APPRAISAL_INITIALIZED']
 
     context 'when hitting #show' do
       subject(:make_request) do
-        if Rails::VERSION::MAJOR >= 5
-          get :show, params: { id: id, include: 'books' }
-        else
-          get :show, id: id, params: {
-            id: id, include: 'books'
-          }
-        end
+        do_show({ id: id, include: 'books' })
       end
 
       let(:id) { author1.id.to_s }
@@ -659,10 +653,10 @@ if ENV['APPRAISAL_INITIALIZED']
     context 'when passing sparse fieldsets on primary data' do
       context 'and sideloading' do
         it 'is able to sideload without adding the field' do
-          get :index, params: {
+          do_index({
             fields: { authors: 'first_name' },
             include: 'books'
-          }
+          })
           expect(json['data'][0]['relationships']).to be_present
           expect(included.map(&:jsonapi_type).uniq).to match_array(%w(books))
         end
@@ -671,16 +665,16 @@ if ENV['APPRAISAL_INITIALIZED']
 
     context 'sideloading has_many' do
       it 'can sideload' do
-        get :index, params: { include: 'books' }
+        do_index({ include: 'books' })
         expect(included('books').map(&:id)).to eq([book1.id, book2.id])
       end
 
       context 'when paginating the sideload' do
         let(:request) do
-          get :index, params: {
+          do_index({
             include: 'books',
             page: { books: { size: 1, number: 2 } }
-          }
+          })
         end
 
         context 'and only 1 parent' do
@@ -704,17 +698,17 @@ if ENV['APPRAISAL_INITIALIZED']
       end
 
       it 'allows sorting of sideloaded resource' do
-        get :index, params: { include: 'books', sort: '-books.id' }
+        do_index({ include: 'books', sort: '-books.id' })
         expect(included('books').map(&:id)).to eq([book2.id, book1.id])
       end
 
       it 'allows filtering of sideloaded resource' do
-        get :index, params: { include: 'books', filter: { books: { id: book2.id } } }
+        do_index({ include: 'books', filter: { books: { id: book2.id } } })
         expect(included('books').map(&:id)).to eq([book2.id])
       end
 
       it 'allows extra fields for sideloaded resource' do
-        get :index, params: { include: 'books', extra_fields: { books: 'alternate_title' } }
+        do_index({ include: 'books', extra_fields: { books: 'alternate_title' } })
         book = included('books')[0]
         expect(book['title']).to be_present
         expect(book['pages']).to be_present
@@ -722,7 +716,7 @@ if ENV['APPRAISAL_INITIALIZED']
       end
 
       it 'allows sparse fieldsets for the sideloaded resource' do
-        get :index, params: { include: 'books', fields: { books: 'pages' } }
+        do_index({ include: 'books', fields: { books: 'pages' } })
         book = included('books')[0]
         expect(book).to_not have_key('title')
         expect(book).to_not have_key('alternate_title')
@@ -730,7 +724,7 @@ if ENV['APPRAISAL_INITIALIZED']
       end
 
       it 'allows extra fields and sparse fieldsets for the sideloaded resource' do
-        get :index, params: { include: 'books', fields: { books: 'pages' }, extra_fields: { books: 'alternate_title' } }
+        do_index({ include: 'books', fields: { books: 'pages' }, extra_fields: { books: 'alternate_title' } })
         book = included('books')[0]
         expect(book).to have_key('pages')
         expect(book).to have_key('alternate_title')
@@ -740,12 +734,12 @@ if ENV['APPRAISAL_INITIALIZED']
 
     context 'sideloading belongs_to' do
       it 'can sideload' do
-        get :index, params: { include: 'state' }
+        do_index({ include: 'state' })
         expect(included('states').map(&:id)).to eq([state.id])
       end
 
       it 'allows extra fields for sideloaded resource' do
-        get :index, params: { include: 'state', extra_fields: { states: 'population' } }
+        do_index({ include: 'state', extra_fields: { states: 'population' } })
         state = included('states')[0]
         expect(state['name']).to be_present
         expect(state['abbreviation']).to be_present
@@ -753,7 +747,7 @@ if ENV['APPRAISAL_INITIALIZED']
       end
 
       it 'allows sparse fieldsets for the sideloaded resource' do
-        get :index, params: { include: 'state', fields: { states: 'name' } }
+        do_index({ include: 'state', fields: { states: 'name' } })
         state = included('states')[0]
         expect(state['name']).to be_present
         expect(state).to_not have_key('abbreviation')
@@ -761,7 +755,7 @@ if ENV['APPRAISAL_INITIALIZED']
       end
 
       it 'allows extra fields and sparse fieldsets for the sideloaded resource' do
-        get :index, params: { include: 'state', fields: { states: 'name' }, extra_fields: { states: 'population' } }
+        do_index({ include: 'state', fields: { states: 'name' }, extra_fields: { states: 'population' } })
         state = included('states')[0]
         expect(state).to have_key('name')
         expect(state).to have_key('population')
@@ -771,12 +765,12 @@ if ENV['APPRAISAL_INITIALIZED']
 
     context 'sideloading has_one' do
       it 'can sideload' do
-        get :index, params: { include: 'bio' }
+        do_index({ include: 'bio' })
         expect(included('bios').map(&:id)).to eq([bio.id])
       end
 
       it 'allows extra fields for sideloaded resource' do
-        get :index, params: { include: 'bio', extra_fields: { bios: 'created_at' } }
+        do_index({ include: 'bio', extra_fields: { bios: 'created_at' } })
         bio = included('bios')[0]
         expect(bio['description']).to be_present
         expect(bio['created_at']).to be_present
@@ -784,7 +778,7 @@ if ENV['APPRAISAL_INITIALIZED']
       end
 
       it 'allows sparse fieldsets for the sideloaded resource' do
-        get :index, params: { include: 'bio', fields: { bios: 'description' } }
+        do_index({ include: 'bio', fields: { bios: 'description' } })
         bio = included('bios')[0]
         expect(bio['description']).to be_present
         expect(bio).to_not have_key('created_at')
@@ -792,7 +786,7 @@ if ENV['APPRAISAL_INITIALIZED']
       end
 
       it 'allows extra fields and sparse fieldsets for the sideloaded resource' do
-        get :index, params: { include: 'bio', fields: { bios: 'description' }, extra_fields: { bios: 'created_at' } }
+        do_index({ include: 'bio', fields: { bios: 'description' }, extra_fields: { bios: 'created_at' } })
         bio = included('bios')[0]
         expect(bio).to have_key('description')
         expect(bio).to have_key('created_at')
@@ -806,7 +800,7 @@ if ENV['APPRAISAL_INITIALIZED']
 
         it 'still uses the activerecord adapter, not the PORO adapter' do
           expect_any_instance_of(Legacy::Author).to_not receive(:bio=)
-          get :index, params: { include: 'bio' }
+          do_index({ include: 'bio' })
           expect(json['data'][0]['relationships']['bio']['data'])
             .to be_nil
         end
@@ -823,7 +817,7 @@ if ENV['APPRAISAL_INITIALIZED']
           end
 
           it 'still works' do
-            get :index, params: { include: 'bio.bio_labels' }
+            do_index({ include: 'bio.bio_labels' })
             expect(included('bio_labels').length).to eq(1)
           end
         end
@@ -832,28 +826,28 @@ if ENV['APPRAISAL_INITIALIZED']
 
     context 'sideloading many_to_many' do
       it 'can sideload' do
-        get :index, params: { include: 'hobbies' }
+        do_index({ include: 'hobbies' })
         expect(included('hobbies').map(&:id)).to eq([hobby1.id, hobby2.id])
       end
 
       it 'allows sorting of sideloaded resource' do
-        get :index, params: { include: 'hobbies', sort: '-hobbies.name' }
+        do_index({ include: 'hobbies', sort: '-hobbies.name' })
         expect(included('hobbies').map(&:id)).to eq([hobby2.id, hobby1.id])
       end
 
       it 'allows filtering of sideloaded resource' do
-        get :index, params: {
+        do_index({
           include: 'hobbies',
           filter: { hobbies: { id: hobby2.id } }
-        }
+        })
         expect(included('hobbies').map(&:id)).to eq([hobby2.id])
       end
 
       it 'allows extra fields for sideloaded resource' do
-        get :index, params: {
+        do_index({
           include: 'hobbies',
           extra_fields: { hobbies: 'reason' }
-        }
+        })
         hobby = included('hobbies')[0]
         expect(hobby['name']).to be_present
         expect(hobby['description']).to be_present
@@ -861,7 +855,7 @@ if ENV['APPRAISAL_INITIALIZED']
       end
 
       it 'allows sparse fieldsets for the sideloaded resource' do
-        get :index, params: { include: 'hobbies', fields: { hobbies: 'name' } }
+        do_index({ include: 'hobbies', fields: { hobbies: 'name' } })
         hobby = included('hobbies')[0]
         expect(hobby['name']).to be_present
         expect(hobby).to_not have_key('description')
@@ -869,11 +863,11 @@ if ENV['APPRAISAL_INITIALIZED']
       end
 
       it 'allows extra fields and sparse fieldsets for the sideloaded resource' do
-        get :index, params: {
+        do_index({
           include: 'hobbies',
           fields: { hobbies: 'name' },
           extra_fields: { hobbies: 'reason' }
-        }
+        })
         hobby = included('hobbies')[0]
         expect(hobby).to have_key('name')
         expect(hobby).to have_key('reason')
@@ -881,11 +875,11 @@ if ENV['APPRAISAL_INITIALIZED']
       end
 
       it 'allows extra fields and sparse fieldsets for multiple resources' do
-        get :index, params: {
+        do_index({
           include: 'hobbies,books',
           fields: { hobbies: 'name', books: 'title',  },
           extra_fields: { hobbies: 'reason', books: 'alternate_title' },
-        }
+        })
         hobby = included('hobbies')[0]
         book = included('books')[0]
         expect(hobby).to have_key('name')
@@ -897,7 +891,7 @@ if ENV['APPRAISAL_INITIALIZED']
       end
 
       it 'does not duplicate results' do
-        get :index, params: { include: 'hobbies' }
+        do_index({ include: 'hobbies' })
         author1_relationships = json['data'][0]['relationships']
         author2_relationships = json['data'][1]['relationships']
 
@@ -928,7 +922,7 @@ if ENV['APPRAISAL_INITIALIZED']
         let!(:other_table_hobby2)  { Legacy::Hobby.create!(name: 'Woodworking', authors: [author1, author2]) }
 
         it 'still works' do
-          get :index, params: { include: 'hobbies' }
+          do_index({ include: 'hobbies' })
           expect(included('hobbies').map(&:id))
             .to eq([other_table_hobby1.id, other_table_hobby2.id])
         end
@@ -937,7 +931,7 @@ if ENV['APPRAISAL_INITIALIZED']
 
     context 'sideloading self-referential' do
       it 'works' do
-        get :index, params: { include: 'organization.children' }
+        do_index({ include: 'organization.children' })
         includes = included('organizations')
         expect(includes[0]['name']).to eq('Org1')
         expect(includes[1]['name']).to eq('Org2')
@@ -960,20 +954,20 @@ if ENV['APPRAISAL_INITIALIZED']
       it 'works' do
         book2.genre = Legacy::Genre.create! name: 'Comedy'
         book2.save!
-        get :index, params: {
+        do_index({
           filter: { books: { id: book1.id }, other_books: { id: book2.id } },
           include: 'books.genre,other_books.genre'
-        }
+        })
         expect(included('genres').length).to eq(2)
       end
     end
 
     context 'sideloading polymorphic belongs_to' do
       it 'allows extra fields for the sideloaded resource' do
-        get :index, params: {
+        do_index({
           include: 'dwelling',
           extra_fields: { houses: 'house_price', condos: 'condo_price' }
-        }
+        })
         house = included('houses')[0]
         expect(house['name']).to be_present
         expect(house['house_description']).to be_present
@@ -985,10 +979,10 @@ if ENV['APPRAISAL_INITIALIZED']
       end
 
       it 'allows sparse fieldsets for the sideloaded resource' do
-        get :index, params: {
+        do_index({
           include: 'dwelling',
           fields: { houses: 'name', condos: 'condo_description' }
-        }
+        })
         house = included('houses')[0]
         expect(house['name']).to be_present
         expect(house).to_not have_key('house_description')
@@ -1000,11 +994,11 @@ if ENV['APPRAISAL_INITIALIZED']
       end
 
       it 'allows extra fields and sparse fieldsets for the sideloaded resource' do
-        get :index, params: {
+        do_index({
           include: 'dwelling',
           fields: { houses: 'name', condos: 'condo_description' },
           extra_fields: { houses: 'house_price', condos: 'condo_price' }
-        }
+        })
         house = included('houses')[0]
         condo = included('condos')[0]
         expect(house).to have_key('name')
@@ -1017,7 +1011,7 @@ if ENV['APPRAISAL_INITIALIZED']
 
       # NB: Condo does NOT have a state relationship
       it 'allows additional levels of nesting' do
-        get :index, params: { include: 'dwelling.state' }
+        do_index({ include: 'dwelling.state' })
         expect(included('states').length).to eq(1)
       end
     end

--- a/spec/integration/rails/hooks_spec.rb
+++ b/spec/integration/rails/hooks_spec.rb
@@ -154,7 +154,7 @@ if ENV["APPRAISAL_INITIALIZED"]
       end
 
       it 'fires hooks correctly' do
-        post :create, params: payload
+        do_create(payload)
 
         expect(Callbacks.fired.keys).to match_array([:after_create, :after_save])
         author, books = Callbacks.fired[:after_create]
@@ -174,7 +174,7 @@ if ENV["APPRAISAL_INITIALIZED"]
       end
 
       it 'fires hooks correctly' do
-        post :create, params: payload
+        do_create(payload)
 
         expect(Callbacks.fired.keys)
           .to match_array([:after_update, :after_save])
@@ -194,7 +194,7 @@ if ENV["APPRAISAL_INITIALIZED"]
       end
 
       it 'fires hooks correctly' do
-        post :create, params: payload
+        do_create(payload)
 
         expect(Callbacks.fired.keys).to match_array([:after_destroy, :after_save])
         author, books = Callbacks.fired[:after_destroy]
@@ -215,7 +215,7 @@ if ENV["APPRAISAL_INITIALIZED"]
       end
 
       it 'fires hooks correctly' do
-        post :create, params: payload
+        do_create(payload)
 
         expect(Callbacks.fired.keys).to match_array([:after_disassociate, :after_save])
         author, books = Callbacks.fired[:after_disassociate]
@@ -238,7 +238,8 @@ if ENV["APPRAISAL_INITIALIZED"]
       end
 
       it 'also works' do
-        post :create, params: payload
+        do_create(payload)
+
         expect(Callbacks.fired.keys).to match_array([:state_after_create])
         author, states = Callbacks.fired[:state_after_create]
         state = states[0]

--- a/spec/integration/rails/persistence_with_finders_spec.rb
+++ b/spec/integration/rails/persistence_with_finders_spec.rb
@@ -1,0 +1,174 @@
+if ENV["APPRAISAL_INITIALIZED"]
+  ::PersistenceTestsController = Class.new(ApplicationController, &EMPLOYEE_CONTROLLER_BLOCK)
+
+  RSpec.describe 'persisting and retrieving in a single request', type: :request do
+    before do
+      Rails.application.routes.draw do
+        post '/employees', to: PersistenceTestsController.action(:create)
+        put '/employees/:id', to: PersistenceTestsController.action(:update)
+      end
+    end
+
+    after do
+      Rails.application.reload_routes!
+    end
+
+    let(:params) { {} }
+
+    subject(:make_request) do
+      if Rails::VERSION::MAJOR == 4
+        send(request_method, request_path, payload)
+      else
+        send(request_method, request_path, params: payload)
+      end
+    end
+
+    let(:request_path) { "#{path}?#{params.to_param}" }
+
+    describe 'update' do
+      let(:request_method) { :put }
+      let(:path) { "/employees/#{employee.id}" }
+
+      let(:employee) do
+        Employee.create(first_name: 'Joe', last_name: 'Blow', nickname: "Slugger")
+      end
+
+      let(:payload) do
+        {
+          data: {
+            id: employee.id,
+            type: 'employees',
+            attributes: { first_name: 'Jane' }
+          }
+        }
+      end
+
+      it 'updates the data correctly' do
+        expect {
+          make_request
+        }.to change { employee.reload.first_name }.from('Joe').to('Jane')
+      end
+
+      context 'when specific fields and sideloads are requested' do
+        let!(:salary) { Salary.create!(base_rate: 80, overtime_rate: 800, employee: employee) }
+
+        let(:params) do
+          {
+            fields: {
+              employees: 'first_name',
+              salaries: 'base_rate'
+            },
+            extra_fields: {
+              employees: 'nickname'
+            },
+            include: 'salary'
+          }
+        end
+
+        it 'responds with only the requested fields' do
+          make_request
+
+          expect(jsonapi_data.attributes).to eq({
+            'id' => employee.id.to_s,
+            'jsonapi_type' => 'employees',
+            'first_name' => 'Jane',
+            'nickname' => 'Slugger',
+          })
+        end
+
+        it 'includes requested sideloads and their requested fields' do
+          make_request
+
+          expect(included('salaries').first.attributes).to eq({
+            'id' => salary.id.to_s,
+            'jsonapi_type' => 'salaries',
+            'base_rate' => 80.0,
+          })
+        end
+      end
+
+      describe 'nested update' do
+        let!(:employee)   { Employee.create!(first_name: 'original', positions: [position1, position2], teams: teams) }
+        let!(:position1)  { Position.create!(title: 'unchanged') }
+        let!(:position2)  { Position.create!(title: 'original', department: department) }
+        let!(:department) { Department.create!(name: 'original') }
+        let!(:salary) { Salary.create!(base_rate: 80, overtime_rate: 800, employee: employee) }
+        let!(:teams) { [Team.create!(name: 'The A Team'), Team.create!(name: 'The X Men')] }
+
+        let(:path) { "/employees/#{employee.id}" }
+
+        let(:payload) do
+          {
+            data: {
+              id: employee.id,
+              type: 'employees',
+              attributes: { first_name: 'updated first name' },
+              relationships: {
+                positions: {
+                  data: [
+                    { type: 'positions', id: position2.id.to_s, method: 'update' }
+                  ]
+                },
+                salary: {
+                  data: { type: 'salaries', id: salary.id.to_s, method: 'update' }
+                }
+              }
+            },
+            included: [
+              {
+                type: 'positions',
+                id: position2.id.to_s,
+                attributes: { title: 'updated title' },
+                relationships: {
+                  department: {
+                    data: { type: 'departments', id: department.id.to_s, method: 'update' }
+                  }
+                }
+              },
+              {
+                type: 'departments',
+                id: department.id.to_s,
+                attributes: { name: 'updated name' }
+              },
+              {
+                type: 'salaries',
+                id: salary.id.to_s,
+                attributes: { base_rate: 600 }
+              }
+            ]
+          }
+        end
+
+        context 'when positions and teams are included in requested output' do
+          let(:params) do
+            {
+              include: 'positions,teams'
+            }
+          end
+
+          it 'updates only the provided objects' do
+            expect {
+              make_request
+            }.not_to change { employee.teams }
+
+            employee.reload
+            expect(employee.first_name).to eq('updated first name')
+            expect(employee.positions[0].title).to eq('unchanged')
+            expect(employee.positions[1].title).to eq('updated title')
+            expect(employee.positions[1].department.name).to eq('updated name')
+            expect(employee.salary.base_rate).to eq(600)
+          end
+
+          it 'sideloads the updated objects plus included objects' do
+            make_request
+
+            expect(included('teams').length).to eq(2)
+            expect(included('positions').length).to eq(2)
+            expect(included('departments').length).to eq(1)
+            expect(included('salaries').length).to eq(1)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/rails/sideload_allowlist_spec.rb
+++ b/spec/integration/rails/sideload_allowlist_spec.rb
@@ -29,7 +29,7 @@ if ENV["APPRAISAL_INITIALIZED"]
 
     context 'when no sideload allowlist' do
       it 'allows loading all relationships' do
-        get :index, params: { include: 'books.genre' }
+        do_index({ include: 'books.genre' })
         expect(json_includes('books')).to_not be_blank
         expect(json_includes('genres')).to_not be_blank
       end
@@ -44,7 +44,7 @@ if ENV["APPRAISAL_INITIALIZED"]
       end
 
       it 'restricts what sideloads can be loaded' do
-        get :index, params: { include: 'books.genre' }
+        do_index({ include: 'books.genre' })
         expect(json_includes('books')).to_not be_blank
         expect(json_includes('genres')).to be_blank
       end

--- a/spec/integration/rails/sunspot_pattern_spec.rb
+++ b/spec/integration/rails/sunspot_pattern_spec.rb
@@ -34,13 +34,13 @@ if ENV['APPRAISAL_INITIALIZED']
     let(:path) { '/legacy/author_searches' }
 
     it 'works' do
-      get :index, params: { include: 'special_books' }
+      do_index({ include: 'special_books' })
       expect(d[0].sideload(:special_books).map(&:id)).to eq([book.id])
     end
 
     context 'belongs_to' do
       it 'works' do
-        get :index, params: { include: 'special_state' }
+        do_index({ include: 'special_state' })
         expect(d[0].sideload(:special_state).id).to eq(state.id)
       end
     end

--- a/spec/rails_spec_helper.rb
+++ b/spec/rails_spec_helper.rb
@@ -51,19 +51,10 @@ end
 class ApplicationController < ActionController::Base
   include Rails.application.routes.url_helpers
   include Graphiti::Rails
-
-  prepend_before_action :fix_params!
-
-  private
-
-  # Honestly not sure why this is needed
-  # Otherwise params is { params: actual_params }
-  def fix_params!
-    if Rails::VERSION::MAJOR == 4
-      good_params = { action: action_name }.merge(params[:params] || {})
-      self.params = ActionController::Parameters.new(good_params.with_indifferent_access)
-    end
-  end
 end
 
 require 'rspec/rails'
+
+RSpec.configure do |config|
+  config.include UniversalControllerSpecHelper
+end

--- a/spec/scope_spec.rb
+++ b/spec/scope_spec.rb
@@ -46,13 +46,8 @@ RSpec.describe Graphiti::Scope do
 
         it 'resolves the sideload' do
           expect(sideload).to receive(:resolve)
-            .with(results, query.sideloads[:positions], anything)
+            .with(results, query.sideloads[:positions], resource)
           instance.resolve
-        end
-
-        context 'and it is nested within the same namespace' do
-          xit 'resolves with the correct namespace' do
-          end
         end
 
         context 'but no parents were found' do
@@ -73,6 +68,38 @@ RSpec.describe Graphiti::Scope do
 
       it 'returns empty array' do
         expect(instance.resolve).to eq([])
+      end
+    end
+  end
+
+  describe '#resolve_sideloads' do
+    let(:sideload) { double(name: :positions) }
+    let(:results)  { [double.as_null_object] }
+
+    before do
+      params[:include] = { positions: {} }
+      objekt = instance.instance_variable_get(:@object)
+      allow(resource).to receive(:resolve).with(objekt) { results }
+    end
+
+    context 'when the requested sideload exists on the resource' do
+      before do
+        allow(resource.class).to receive(:sideload).with(:positions) { sideload }
+      end
+
+      it 'resolves the sideload' do
+        expect(sideload).to receive(:resolve)
+          .with(results, query.sideloads[:positions], resource)
+        instance.resolve_sideloads(results)
+      end
+
+      context 'but no parents were found' do
+        let(:results) { [] }
+
+        it 'does not resolve the sideload' do
+          expect(sideload).to_not receive(:resolve)
+          instance.resolve_sideloads(results)
+        end
       end
     end
   end

--- a/spec/support/rails/employee_controller.rb
+++ b/spec/support/rails/employee_controller.rb
@@ -1,0 +1,37 @@
+EMPLOYEE_CONTROLLER_BLOCK = lambda do |*args|
+  def create
+    employee = EmployeeResource.build(params)
+
+    if employee.save
+      render jsonapi: employee
+    else
+      render json: {
+        errors: {
+          employee: employee.errors,
+          positions: employee.data.positions.map(&:errors),
+          departments: employee.data.positions.map(&:department).compact.map(&:errors)
+        }
+      }
+    end
+  end
+
+  def update
+    employee = EmployeeResource.find(params)
+
+    if employee.update_attributes
+      render jsonapi: employee
+    else
+      render json: { error: employee.errors }
+    end
+  end
+
+  def destroy
+    employee = EmployeeResource.find(params)
+
+    if employee.destroy
+      render json: { meta: {} }
+    else
+      render json: { error: employee.errors }
+    end
+  end
+end

--- a/spec/support/rails/universal_controller_spec_helper.rb
+++ b/spec/support/rails/universal_controller_spec_helper.rb
@@ -1,0 +1,29 @@
+module UniversalControllerSpecHelper
+  def universal_process(method, action, params)
+    if Rails::VERSION::MAJOR == 4
+      send(method, action, params)
+    else
+      send(method, action, params: params)
+    end
+  end
+
+  def do_create(params)
+    universal_process(:post, :create, params)
+  end
+
+  def do_show(params)
+    universal_process(:get, :show, params)
+  end
+
+  def do_index(params)
+    universal_process(:get, :index, params)
+  end
+
+  def do_update(params)
+    universal_process(:put, :update, params)
+  end
+
+  def do_destroy(params)
+    universal_process(:delete, :destroy, params)
+  end
+end


### PR DESCRIPTION
This will allow persistence methods to request specific additional
includes, stats, or fields serialization on the response.  The response
object will always include any updated records, and additionally will
sideload anything that is requested.

Note that the first commit is just cleanup of request specs to simplify the rails4/5 behavior split.  Real behavior starts in later commits.