### PR TITLE
Add default_attributes class method to ApplicationResource

### DIFF
--- a/lib/generators/graphiti/templates/application_resource.rb.erb
+++ b/lib/generators/graphiti/templates/application_resource.rb.erb
@@ -12,4 +12,12 @@ class ApplicationResource < Graphiti::Resource
   self.adapter = Graphiti::Adapters::ActiveRecord
   self.base_url = Rails.application.routes.default_url_options[:host]
   self.endpoint_namespace = '<%= api_namespace %>'
+
+
+  def self.default_attributes
+    klass = self.to_s.gsub(/Resource$/,"").constantize
+    klass.columns.each do |c|
+      attribute c.name.to_sym, c.type
+    end
+  end
 end

--- a/lib/generators/graphiti/templates/resource.rb.erb
+++ b/lib/generators/graphiti/templates/resource.rb.erb
@@ -1,10 +1,14 @@
 <% module_namespacing do -%>
 class <%= class_name %>Resource < ApplicationResource
+  <%- if attributes.empty? -%>
+  default_attributes
+  <%- else -%>
   <%- attributes.each do |a| -%>
   <%- if [:created_at, :updated_at].include?(a.name.to_sym) -%>
   attribute :<%= a.name %>, :<%= a.type %>, writable: false
   <%- else -%>
   attribute :<%= a.name %>, :<%= a.type %>
+  <%- end -%>
   <%- end -%>
   <%- end -%>
 end


### PR DESCRIPTION
If attributes aren't supplied for the graphiti:resource, it's possible
to derive the attributes from the existing schema for the model.