### PR TITLE
Fix sideposting of polymorphic resources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ script: "bundle exec rake"
 
 install: bundle install --retry=3 --jobs=3
 
+#https://docs.travis-ci.com/user/languages/ruby/
+before_install:
+  - gem install bundler -v '< 2'
+
 gemfile:
   - gemfiles/rails_4.gemfile
   - gemfiles/rails_5.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.3
   - 2.4
   - 2.5
 

--- a/graphiti.gemspec
+++ b/graphiti.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "activerecord", ['>= 4.1', '< 6']
   spec.add_development_dependency "kaminari", '~> 0.17'
-  spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "database_cleaner"

--- a/lib/graphiti/util/persistence.rb
+++ b/lib/graphiti/util/persistence.rb
@@ -162,8 +162,11 @@ class Graphiti::Util::Persistence
       iterate(except: [:polymorphic_belongs_to, :belongs_to]) do |x|
         yield x
 
-        x[:object] = x[:sideload].resource
-          .persist_with_relationships(x[:meta], x[:attributes], x[:relationships], caller_model)
+        if x[:sideload].writable?
+          x[:object] = x[:resource]
+            .persist_with_relationships(x[:meta], x[:attributes], x[:relationships], caller_model)
+        end
+
         processed << x
       end
     end
@@ -173,7 +176,7 @@ class Graphiti::Util::Persistence
     [].tap do |processed|
       iterate(only: [:polymorphic_belongs_to, :belongs_to]) do |x|
         if x[:sideload].writable?
-          x[:object] = x[:sideload].resource
+          x[:object] = x[:resource]
             .persist_with_relationships(x[:meta], x[:attributes], x[:relationships])
         else
           raise Graphiti::Errors::UnwritableRelationship.new(@resource, x[:sideload])

--- a/lib/graphiti/util/relationship_payload.rb
+++ b/lib/graphiti/util/relationship_payload.rb
@@ -45,12 +45,21 @@ module Graphiti
       def payload_for(sideload, relationship_payload)
         type = relationship_payload[:meta][:jsonapi_type].to_sym
 
-        if sideload.resource.type != type && sideload.polymorphic_parent?
+        # For polymorphic *sideloads*, grab the correct child sideload
+        if sideload.resource.type != type && sideload.type == :polymorphic_belongs_to
           sideload = sideload.child_for_type(type)
         end
+
+        # For polymorphic *resources*, grab the correct child resource
+        resource = sideload.resource
+        if resource.type != type && resource.polymorphic?
+          resource = resource.class.resource_for_type(type).new
+        end
+
         relationship_payload[:meta][:method] ||= :update
 
         {
+          resource: resource,
           sideload: sideload,
           is_polymorphic: sideload.polymorphic_child?,
           primary_key: sideload.primary_key,

--- a/spec/fixtures/employee_directory.rb
+++ b/spec/fixtures/employee_directory.rb
@@ -15,6 +15,12 @@ ActiveRecord::Schema.define(:version => 1) do
     t.string :name
   end
 
+  create_table :tasks do |t|
+    t.integer :employee_id
+    t.string :type
+    t.string :name
+  end
+
   create_table :employee_teams do |t|
     t.integer :team_id
     t.integer :employee_id
@@ -91,10 +97,22 @@ class HomeOffice < ApplicationRecord
   has_many :employees, as: :workspace
 end
 
+class Task < ApplicationRecord
+end
+
+class Bug < Task
+end
+
+class Feature < Task
+end
+
 class Employee < ApplicationRecord
   belongs_to :workspace, polymorphic: true
   belongs_to :classification
   has_many :positions
+  has_many :tasks
+  has_many :bugs
+  has_many :features
   validates :first_name, presence: true
   validates :delete_confirmation,
     presence: true,
@@ -151,6 +169,18 @@ class PositionResource < ApplicationResource
   belongs_to :department
 end
 
+class TaskResource < ApplicationResource
+  self.polymorphic = %w(BugResource FeatureResource)
+  attribute :name, :string
+  attribute :employee_id, :string, only: [:writable]
+end
+
+class BugResource < TaskResource
+end
+
+class FeatureResource < TaskResource
+end
+
 class OfficeResource < ApplicationResource
   attribute :address, :string
 end
@@ -179,6 +209,7 @@ class EmployeeResource < ApplicationResource
   extra_attribute :professional_titles, :string
 
   has_many :positions
+  has_many :tasks
   has_one :salary
   belongs_to :classification
   many_to_many :teams, description: "Teams the employee belongs to"

--- a/spec/integration/rails/persistence_spec.rb
+++ b/spec/integration/rails/persistence_spec.rb
@@ -766,7 +766,49 @@ if ENV["APPRAISAL_INITIALIZED"]
       end
     end
 
-    describe 'nested polymorphic relationship' do
+    describe 'nested relationship to polymorphic resource' do
+      subject(:make_request) do
+        do_create(payload)
+      end
+
+      let(:payload) do
+        {
+          data: {
+            type: 'employees',
+            attributes: { first_name: 'Joe' },
+            relationships: {
+              tasks: {
+                data: [
+                  { :'temp-id' => 'abc123', type: 'features', method: 'create' },
+                  { :'temp-id' => 'abc456', type: 'bugs', method: 'create' }
+                ]
+              }
+            }
+          },
+          included: [
+            {
+              :'temp-id' => 'abc123',
+              type: 'features',
+              attributes: { name: 'test feature' }
+            },
+            {
+              :'temp-id' => 'abc456',
+              type: 'bugs',
+              attributes: { name: 'test bug' }
+            }
+          ]
+        }
+      end
+
+      it 'creates correct records' do
+        make_request
+        employee = Employee.last
+        expect(employee.features.length).to eq(1)
+        expect(employee.bugs.length).to eq(1)
+      end
+    end
+
+    describe 'nested polymorphic_belongs_to relationship' do
       let(:workspace_type) { 'offices' }
 
       subject(:make_request) do


### PR DESCRIPTION
This is when the relationship is a normal has_many/belongs_to, but the
Resource is polymorphic and a specific jsonapi type is used. In this
case, we should be going through the correct child resource that matches
the jsonapi type for the logic.

Fixes https://github.com/graphiti-api/graphiti/issues/56